### PR TITLE
Add Alt+/ hotkey to toggle listening

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Offline/online voice interaction (local, private, or Google Gemini fallback)**
 - **Hotword detection, hard/soft mute, and wake/sleep phrases**
 - **Priority 'Stop Assistant' hotword to cancel speech**
+- **Alt+/ hotkey toggles voice listening on or off**
 - **Unified voice profile for all TTS output**
 - **Live config editing:** Change `config.json` and see it reload instantly (no restart needed)
 - **Powerful memory search and recall**

--- a/modules/listen_hotkey.py
+++ b/modules/listen_hotkey.py
@@ -1,0 +1,39 @@
+"""Hotkey to toggle assistant listening state."""
+
+try:
+    import keyboard
+except Exception as e:  # pragma: no cover - optional dependency
+    keyboard = None
+    _IMPORT_ERROR = e
+else:
+    _IMPORT_ERROR = None
+
+from assistant import is_listening, set_listening, cancel_processing
+from modules.tts_manager import stop_speech
+
+HOTKEY = 'alt+/'
+
+__all__ = ["start_hotkey", "trigger"]
+
+
+def start_hotkey():
+    """Register the listening toggle hotkey."""
+    if keyboard is None:
+        return f"keyboard module missing: {_IMPORT_ERROR}"
+    keyboard.add_hotkey(HOTKEY, trigger)
+    return f"Hotkey {HOTKEY} registered"
+
+
+def trigger():
+    """Toggle listening; stop tasks if already listening."""
+    if is_listening():
+        stop_speech()
+        cancel_processing()
+        set_listening(False)
+    else:
+        set_listening(True)
+
+
+def get_description() -> str:
+    """Return a short description of this module."""
+    return "Registers a hotkey to start or cancel voice listening."

--- a/tests/test_listen_hotkey.py
+++ b/tests/test_listen_hotkey.py
@@ -1,0 +1,36 @@
+import importlib
+import types
+from tests.test_assistant_utils import import_assistant
+
+
+def test_start_hotkey_missing_keyboard(monkeypatch):
+    hk = importlib.import_module('modules.listen_hotkey')
+    monkeypatch.setattr(hk, 'keyboard', None)
+    monkeypatch.setattr(hk, '_IMPORT_ERROR', RuntimeError('missing'))
+    out = hk.start_hotkey()
+    assert 'keyboard module missing' in out
+
+
+def test_start_hotkey(monkeypatch):
+    hk = importlib.import_module('modules.listen_hotkey')
+    events = []
+    fake_kb = types.SimpleNamespace(add_hotkey=lambda k, cb: events.append(k))
+    monkeypatch.setattr(hk, 'keyboard', fake_kb)
+    monkeypatch.setattr(hk, '_IMPORT_ERROR', None)
+    out = hk.start_hotkey()
+    assert hk.HOTKEY in out
+    assert events == [hk.HOTKEY]
+
+
+def test_trigger_toggle(monkeypatch):
+    assistant, _ = import_assistant(monkeypatch)
+    hk = importlib.import_module('modules.listen_hotkey')
+    monkeypatch.setattr(hk, 'set_listening', assistant.set_listening)
+    monkeypatch.setattr(hk, 'is_listening', assistant.is_listening)
+    monkeypatch.setattr(hk, 'cancel_processing', lambda: None)
+    monkeypatch.setattr(hk, 'stop_speech', lambda: None)
+    assistant.set_listening(False)
+    hk.trigger()
+    assert assistant.is_listening() is True
+    hk.trigger()
+    assert assistant.is_listening() is False


### PR DESCRIPTION
## Summary
- add `listen_hotkey` module to toggle listening on Alt+/ press
- document new hotkey in README
- cover hotkey logic with tests

## Testing
- `ruff check modules/listen_hotkey.py tests/test_listen_hotkey.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688287f8082c8324a39b336403fcea67