### PR TITLE
Add config editor tab to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **TTS speed, volume, and voice adjustable via config or voice command**
 - **Fast onboarding: all config, shortcuts, and memory are editable text**
 - **Memory viewer/editor:** adjust stored history and `memory_max` from the GUI
+- **Config editor tab:** tweak and save `config.json` without leaving the app
 - **Automatic .exe scanning builds a registry of installed applications**
 - **Startup system/device/network scans populate registries and can be refreshed by voice**
 - **Close or terminate apps by window title or process name (e.g. "terminate Rocket League")**


### PR DESCRIPTION
## Summary
- extend the Tkinter notebook with a `Config Editor` tab
- load config.json in a text box and allow saving and reloading
- document the new tab in the README

## Testing
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828b727bc08324b4ccb7c9667595dc