### PR TITLE
Support multi-command user input

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Close or terminate apps by window title or process name (e.g. "terminate Rocket League")**
 - **List open windows via the taskbar (e.g. "what windows are open?")**
 - **Control music playback with media keys (play/pause, skip) using keyboard, Windows API, or pyautogui fallbacks**
+- **Automatic multi-command parsing:** say "play music and open Rocket League" to run tasks one after another
 - **Tutorial mode:** ask "what does `function_name` do?" to hear documentation
 - **Emulation mode:** set `emulate_actions` to true to practice commands safely
 - **Crash prevention:** unexpected errors are logged and the assistant says "Crash prevented" before resuming

--- a/assistant.py
+++ b/assistant.py
@@ -255,6 +255,19 @@ def process_input(user_input, output_widget):
         output_widget.see("end")
         queue_command(text, output_widget)
         return
+
+    # --- Multi-task handling without explicit "plan" ---
+    plan = planning_agent.create_plan(text)
+    if len(plan) > 1 and not text.lower().startswith("plan "):
+        pending_commands.clear()
+        for sub in plan:
+            queue_command(sub, output_widget)
+        msg = "Queued tasks: " + ", ".join(plan)
+        output_widget.insert("end", f"Assistant: {msg}\n")
+        output_widget.see("end")
+        speak(msg)
+        _run_next_in_queue()
+        return
     set_state("processing")
     global listening_before_processing
     # Save the current listening state before processing

--- a/tests/test_multi_task.py
+++ b/tests/test_multi_task.py
@@ -1,0 +1,19 @@
+from tests.test_assistant_utils import import_assistant
+
+
+class DummyWidget:
+    def insert(self, *a, **kw):
+        pass
+
+    def see(self, *a, **kw):
+        pass
+
+
+def test_process_input_multiple_commands(monkeypatch):
+    assistant, _ = import_assistant(monkeypatch)
+    monkeypatch.setattr(assistant, 'speak', lambda *a, **kw: None)
+    queued = []
+    monkeypatch.setattr(assistant, 'queue_command', lambda t, w: queued.append(t))
+    monkeypatch.setattr(assistant, '_run_next_in_queue', lambda: None)
+    assistant.process_input('play music and open rocket league', DummyWidget())
+    assert queued == ['play music', 'open rocket league']


### PR DESCRIPTION
## Summary
- queue and execute multiple commands from a single phrase
- document automatic multi-command parsing in README
- test multi-command behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882947423148324a97f02d4e30abaeb