### PR TITLE
Improve speech learning training

### DIFF
--- a/tests/test_speech_learning.py
+++ b/tests/test_speech_learning.py
@@ -3,9 +3,11 @@ from modules import speech_learning
 class DummyRec:
     def __init__(self):
         self.count = 0
-    def listen(self, mic, phrase_time_limit=6):
+
+    def listen(self, mic, *a, **kw):
         self.count += 1
         return f"audio{self.count}"
+
     def recognize_google(self, audio):
         return f"heard {audio}"
 
@@ -21,6 +23,30 @@ def test_read_sentences_mock():
     sentences = ["one", "two"]
     out = speech_learning.read_sentences(sentences, recognizer=rec, microphone=mic)
     assert out == ["heard audio1", "heard audio2"]
+
+
+class SilentRec:
+    def listen(self, mic, timeout=1, phrase_time_limit=6):
+        return "audio"
+
+    def recognize_google(self, audio):
+        raise Exception("no speech")
+
+
+def test_cancel_after_timeout(monkeypatch):
+    rec = SilentRec()
+    mic = DummyMic()
+
+    fake = {"t": 0.0}
+
+    def fake_time():
+        fake["t"] += 1.0
+        return fake["t"]
+
+    monkeypatch.setattr(speech_learning, "time", type("T", (), {"time": fake_time, "sleep": lambda x: None}))
+
+    out = speech_learning.read_sentences(["one"], recognizer=rec, microphone=mic, pause_secs=0, cancel_after=5)
+    assert out == [""]
 
 
 def test_get_description():


### PR DESCRIPTION
## Summary
- add pause and inactivity timeout to speech learning
- ensure training loop waits for speech before next prompt
- test cancellation behavior when no speech is detected

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829549443483249e038c823adc7df7