### PR TITLE
Improve LLM module awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Record and play macros on the fly for custom workflows**
 - **Vision/ocr tools:** Screen capture and image recognition by voice or command
 - **Plugin system:** Easy extension with your own Python modules
+- **LLM auto-loads module list for accurate tool usage**
 - **User-friendly GUI with mic overlay and system tray**
 - **Speech learning tab to practice recognition**
 - **Lightweight CLI mode for keyboard power-users**

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -23,6 +23,7 @@ def test_generate_response(monkeypatch):
         return Resp()
 
     monkeypatch.setattr(llm_interface.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(llm_interface, "get_module_overview", lambda: {})
     llm_interface.config["llm_backend"] = "localai"
     result = llm_interface.generate_response("hi", history=[])
     assert result == "ok"
@@ -43,6 +44,7 @@ def test_generate_response_missing_fields(monkeypatch):
         return Resp()
 
     monkeypatch.setattr(llm_interface.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(llm_interface, "get_module_overview", lambda: {})
     llm_interface.config["llm_backend"] = "localai"
     result = llm_interface.generate_response("hi", history=[])
     assert result.startswith("[LLM Error]")

--- a/tests/test_module_overview.py
+++ b/tests/test_module_overview.py
@@ -1,0 +1,18 @@
+import importlib
+from pathlib import Path
+
+from module_manager import get_module_overview
+
+
+def test_get_module_overview(tmp_path, monkeypatch):
+    pkg = tmp_path / "mods"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "demo.py").write_text(
+        "def get_info():\n    return {'name': 'demo', 'functions': ['hello']}\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    info = get_module_overview(str(pkg))
+    assert info == {"demo": ["hello"]}
+    import sys
+    sys.modules.pop("mods", None)


### PR DESCRIPTION
## Summary
- expose new `get_module_overview` helper to list module functions
- inject module list into `generate_response` so the LLM is aware of loaded tools
- include bullet in README about module list awareness
- test `get_module_overview` and patch LLM interface tests

## Testing
- `ruff check module_manager.py llm_interface.py tests/test_llm_interface.py tests/test_module_overview.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829892613883249be52be57310ece4