### PR TITLE
Fix false negative processing message

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -966,12 +966,13 @@ def process_input(user_input, output_widget):
         if result[0]:
             output_widget.insert("end", f"Assistant: {result[0]}\n\n")
             output_widget.see("end")
-            speak(result[0], on_complete=lambda: print("*>"))
+            speak(result[0], on_complete=lambda: print("*>") )
         else:
-            msg = "Sorry, I could not process that."
-            output_widget.insert("end", f"Assistant: {msg}\n\n")
-            output_widget.see("end")
-            last_ai_response = msg
+            if not last_ai_response:
+                msg = "Sorry, I could not process that."
+                output_widget.insert("end", f"Assistant: {msg}\n\n")
+                output_widget.see("end")
+                last_ai_response = msg
             print("*>")
 
     update_state(last_command=last_user_command, last_response=last_ai_response)


### PR DESCRIPTION
## Summary
- do not show apology when an action completed but returned no text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829e4b4c908324a4ab5a0d439c0116