### PR TITLE
Improve crash policy handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Automatic multi-command parsing:** say "play music and open Rocket League" to run tasks one after another
 - **Tutorial mode:** ask "what does `function_name` do?" to hear documentation
 - **Emulation mode:** set `emulate_actions` to true to practice commands safely
-- **Crash prevention:** unexpected errors are logged and the assistant says "Crash prevented" before resuming
+- **Crash prevention:** unexpected errors are logged and the assistant says "Crash prevented" before resuming. Module calls are wrapped so exceptions never terminate the app.
 
 Adjust voice playback on the fly with phrases like "set speech speed to 1.2", "increase volume", or "use jenny voice." The GUI sliders and menu mirror these settings.
 


### PR DESCRIPTION
## Summary
- wrap module function calls with logging so exceptions never bubble up
- document crash policy is stricter
- test that registry.call logs errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68829ec4682c832490b1a437fd3b4fd4