### PR TITLE
Persist learned wake and resume phrases in config

### DIFF
--- a/phrase_manager.py
+++ b/phrase_manager.py
@@ -1,0 +1,60 @@
+import json
+from typing import Any
+from error_logger import log_error
+
+CONFIG_PATH = "config.json"
+MODULE_NAME = "phrase_manager"
+
+
+def _load_all() -> dict:
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:  # pragma: no cover - I/O error
+        log_error(f"[{MODULE_NAME}] Could not load config: {e}")
+        return {}
+
+
+def _save_all(cfg: dict) -> bool:
+    try:
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=2)
+        return True
+    except Exception as e:  # pragma: no cover - I/O error
+        log_error(f"[{MODULE_NAME}] Could not update config: {e}")
+        return False
+
+
+config = _load_all()
+
+
+def _add_phrase(key: str, phrase: str) -> str:
+    phrase = phrase.lower().strip()
+    cfg_list = config.setdefault(key, [])
+    if not phrase or phrase in cfg_list:
+        return "Phrase already known"
+    cfg_list.append(phrase)
+    all_cfg = _load_all() or {}
+    all_cfg.setdefault(key, [])
+    if phrase not in all_cfg[key]:
+        all_cfg[key].append(phrase)
+    if _save_all(all_cfg):
+        config[key] = all_cfg[key]
+        return f"Added {key[:-8] if key.endswith('_phrases') else key} phrase: {phrase}"
+    cfg_list.pop()
+    return "Failed to update config"
+
+
+def add_wake_phrase(phrase: str) -> str:
+    """Persist ``phrase`` to ``wake_phrases`` list in config."""
+    return _add_phrase("wake_phrases", phrase)
+
+
+def add_sleep_phrase(phrase: str) -> str:
+    """Persist ``phrase`` to ``sleep_phrases`` list in config."""
+    return _add_phrase("sleep_phrases", phrase)
+
+
+def add_cancel_phrase(phrase: str) -> str:
+    """Persist ``phrase`` to ``cancel_phrases`` list in config."""
+    return _add_phrase("cancel_phrases", phrase)

--- a/tests/test_pause_listening.py
+++ b/tests/test_pause_listening.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import sys
 import types
 from tests.test_assistant_utils import import_assistant
@@ -47,8 +48,14 @@ def test_learn_resume_phrase(monkeypatch, tmp_path):
     assistant, _ = import_assistant(monkeypatch)
     phrase = 'continue please'
     path = tmp_path / 'state.json'
+    cfg_path = tmp_path / 'config.json'
+    cfg_path.write_text('{}')
     sm = importlib.import_module('state_manager')
-    monkeypatch.setattr(sm, 'STATE_FILE', str(path), raising=False)
     importlib.reload(sm)
+    monkeypatch.setattr(sm, 'STATE_FILE', str(path), raising=False)
+    sm._config_loader = sm.ConfigLoader(str(cfg_path))
+    sm.load_state()
     sm.add_resume_phrase(phrase)
     assert phrase in sm.get_resume_phrases()
+    saved = json.loads(cfg_path.read_text())
+    assert phrase in saved['resume_phrases']

--- a/tests/test_phrase_manager.py
+++ b/tests/test_phrase_manager.py
@@ -1,0 +1,35 @@
+import json
+import importlib
+
+
+def test_add_wake_phrase(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text("{}")
+    pm = importlib.import_module('phrase_manager')
+    monkeypatch.setattr(pm, 'CONFIG_PATH', str(cfg_file), raising=False)
+    pm.config = {}
+
+    msg = pm.add_wake_phrase("jarvis")
+    assert "jarvis" in json.loads(cfg_file.read_text())["wake_phrases"]
+    assert "jarvis" in pm.config["wake_phrases"]
+    assert "Added" in msg
+
+    msg_dup = pm.add_wake_phrase("jarvis")
+    assert "already" in msg_dup
+
+
+def test_add_sleep_and_cancel_phrase(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text("{}")
+    pm = importlib.import_module('phrase_manager')
+    monkeypatch.setattr(pm, 'CONFIG_PATH', str(cfg_file), raising=False)
+    pm.config = {}
+
+    pm.add_sleep_phrase("good night")
+    pm.add_cancel_phrase("abort")
+    saved = json.loads(cfg_file.read_text())
+    assert "good night" in saved["sleep_phrases"]
+    assert "abort" in saved["cancel_phrases"]
+
+
+


### PR DESCRIPTION
## Summary
- add `phrase_manager` helper for config phrase edits
- persist resume phrases to config via `state_manager`
- update assistant phrase learning logic
- add tests for new phrase manager and updated resume phrase learning

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829daddba88324856f9ad416607a6a