### PR TITLE
Add docs for remote Ollama server

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,22 @@ Key options:
 - `min_good_response_words` / `min_good_response_chars`: treat a local
   response as poor quality if shorter than these thresholds.
 
+### Remote Ollama Server
+You can run the LLM on another machine and point the assistant to it over
+your local network:
+1. Start Ollama on the host PC:
+   ```bash
+   ollama serve
+   ```
+   (Assuming the host IP is `192.168.1.50`.)
+2. On the assistant PC, edit `config.json` and set:
+   ```json
+   "llm_url": "http://192.168.1.50:11434/v1/chat/completions"
+   ```
+   This overrides the default local endpoint.
+3. Launch the assistant normally and it will send all LLM requests to the
+   remote Ollama server.
+
 3. Running the Assistant
 GUI Mode:
 python gui_assistant.py

--- a/assistant.py
+++ b/assistant.py
@@ -966,7 +966,7 @@ def process_input(user_input, output_widget):
         if result[0]:
             output_widget.insert("end", f"Assistant: {result[0]}\n\n")
             output_widget.see("end")
-            speak(result[0], on_complete=lambda: print("*>") )
+            speak(result[0], on_complete=lambda: print("*>"))
         else:
             if not last_ai_response:
                 msg = "Sorry, I could not process that."


### PR DESCRIPTION
## Summary
- document how to use a remote Ollama server in README
- fix style issue in assistant.py

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829f66036083249639e81f5863b83e