### PR TITLE
Add wake/sleep hotkey module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Hotword detection, hard/soft mute, and wake/sleep phrases**
 - **Priority 'Stop Assistant' hotword to cancel speech**
 - **Alt+/ hotkey toggles voice listening on or off**
+- **Ctrl+Shift+W wakes the assistant; Ctrl+Shift+S puts it to sleep**
 - **Unified voice profile for all TTS output**
 - **Live config editing:** Change `config.json` and see it reload instantly (no restart needed)
 - **Powerful memory search and recall**

--- a/modules/wake_sleep_hotkey.py
+++ b/modules/wake_sleep_hotkey.py
@@ -1,0 +1,45 @@
+"""Hotkeys to wake or sleep the assistant."""
+
+try:
+    import keyboard
+except Exception as e:  # pragma: no cover - optional dependency
+    keyboard = None
+    _IMPORT_ERROR = e
+else:
+    _IMPORT_ERROR = None
+
+from assistant import is_listening, set_listening, cancel_processing
+from modules.tts_manager import stop_speech
+
+WAKE_HOTKEY = 'ctrl+shift+w'
+SLEEP_HOTKEY = 'ctrl+shift+s'
+
+__all__ = ["start_hotkeys", "trigger_wake", "trigger_sleep"]
+
+
+def start_hotkeys():
+    """Register the wake and sleep hotkeys."""
+    if keyboard is None:
+        return f"keyboard module missing: {_IMPORT_ERROR}"
+    keyboard.add_hotkey(WAKE_HOTKEY, trigger_wake)
+    keyboard.add_hotkey(SLEEP_HOTKEY, trigger_sleep)
+    return f"Hotkeys {WAKE_HOTKEY}, {SLEEP_HOTKEY} registered"
+
+
+def trigger_wake():
+    """Wake the assistant if currently sleeping."""
+    if not is_listening():
+        set_listening(True)
+
+
+def trigger_sleep():
+    """Put the assistant to sleep and cancel active tasks."""
+    if is_listening():
+        stop_speech()
+        cancel_processing()
+        set_listening(False)
+
+
+def get_description() -> str:
+    """Return a short description of this module."""
+    return "Hotkeys for waking or sleeping the assistant."

--- a/tests/test_wake_sleep_hotkey.py
+++ b/tests/test_wake_sleep_hotkey.py
@@ -1,0 +1,39 @@
+import importlib
+import types
+from tests.test_assistant_utils import import_assistant
+
+
+def test_start_hotkeys_missing_keyboard(monkeypatch):
+    mod = importlib.import_module('modules.wake_sleep_hotkey')
+    monkeypatch.setattr(mod, 'keyboard', None)
+    monkeypatch.setattr(mod, '_IMPORT_ERROR', RuntimeError('missing'))
+    out = mod.start_hotkeys()
+    assert 'keyboard module missing' in out
+
+
+def test_start_hotkeys(monkeypatch):
+    mod = importlib.import_module('modules.wake_sleep_hotkey')
+    events = []
+    fake_kb = types.SimpleNamespace(add_hotkey=lambda k, cb: events.append(k))
+    monkeypatch.setattr(mod, 'keyboard', fake_kb)
+    monkeypatch.setattr(mod, '_IMPORT_ERROR', None)
+    out = mod.start_hotkeys()
+    assert mod.WAKE_HOTKEY in out and mod.SLEEP_HOTKEY in out
+    assert events == [mod.WAKE_HOTKEY, mod.SLEEP_HOTKEY]
+
+
+def test_trigger_actions(monkeypatch):
+    assistant, _ = import_assistant(monkeypatch)
+    mod = importlib.import_module('modules.wake_sleep_hotkey')
+
+    monkeypatch.setattr(mod, 'set_listening', assistant.set_listening)
+    monkeypatch.setattr(mod, 'is_listening', assistant.is_listening)
+    monkeypatch.setattr(mod, 'cancel_processing', lambda: None)
+    monkeypatch.setattr(mod, 'stop_speech', lambda: None)
+
+    assistant.set_listening(False)
+    mod.trigger_wake()
+    assert assistant.is_listening() is True
+
+    mod.trigger_sleep()
+    assert assistant.is_listening() is False


### PR DESCRIPTION
## Summary
- add `wake_sleep_hotkey` module for waking and sleeping the assistant via keyboard
- document the new hotkeys in README
- cover module with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a07482288324aa3a06a7d616654a