### PR TITLE
Add module_generator using Codex

### DIFF
--- a/modules/module_generator.py
+++ b/modules/module_generator.py
@@ -1,0 +1,68 @@
+"""Generate new assistant modules using OpenAI Codex."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Optional
+
+from error_logger import log_error
+from module_manager import ModuleRegistry
+from modules.codex_integration import CodexClient
+
+MODULE_NAME = "module_generator"
+
+__all__ = ["generate_module", "get_info", "get_description"]
+
+
+def generate_module(description: str, name: Optional[str] = None) -> str:
+    """Generate a Python module via Codex.
+
+    Parameters
+    ----------
+    description:
+        Plain English description of what the module should do.
+    name:
+        Optional module name. A timestamped name is used if omitted.
+
+    Returns
+    -------
+    str
+        Path to the generated module on success, otherwise an error message.
+    """
+
+    prompt = (
+        "Create a Python module for my local AI assistant. The module should "
+        f"{description}. Provide only code."
+    )
+    try:
+        client = CodexClient()
+        code = client.generate_code(prompt)
+        if not code:
+            return "No code returned"
+        module_name = name or f"codex_module_{int(time.time())}"
+        module_path = os.path.join("modules", f"{module_name}.py")
+        os.makedirs("modules", exist_ok=True)
+        with open(module_path, "w", encoding="utf-8") as f:
+            f.write(code)
+        if os.getcwd() not in os.sys.path:
+            os.sys.path.insert(0, os.getcwd())
+        ModuleRegistry().auto_discover("modules")
+        return module_path
+    except Exception as exc:  # pragma: no cover - network or file failure
+        log_error(f"[module_generator] failed: {exc}")
+        return f"Error: {exc}"
+
+
+def get_info() -> dict:
+    """Return metadata about this module."""
+    return {
+        "name": MODULE_NAME,
+        "description": "Generates new modules on demand using Codex.",
+        "functions": ["generate_module"],
+    }
+
+
+def get_description() -> str:
+    """Short summary describing the module."""
+    return "Utilities for generating assistant modules using OpenAI Codex."

--- a/tests/test_module_generator.py
+++ b/tests/test_module_generator.py
@@ -1,0 +1,58 @@
+import os
+import importlib
+import types
+
+import pytest
+
+from module_manager import ModuleRegistry
+
+
+def fake_post(url, json=None, headers=None, timeout=60):
+    class Dummy:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"choices": [{"text": "def demo():\n    return True"}]}
+
+    return Dummy()
+
+
+@pytest.fixture(autouse=True)
+def _patch_requests(monkeypatch):
+    mod = types.ModuleType("requests")
+    mod.post = fake_post
+    monkeypatch.setitem(importlib.sys.modules, "requests", mod)
+    yield
+
+
+class DummyClient:
+    def __init__(self, engine: str = "test") -> None:
+        pass
+
+    def generate_code(self, prompt: str) -> str:
+        return "def demo():\n    return True"
+
+
+@pytest.fixture(autouse=True)
+def _patch_codex_client(monkeypatch):
+    mg = importlib.import_module("modules.module_generator")
+    monkeypatch.setattr(mg, "CodexClient", lambda: DummyClient())
+    yield
+
+
+def test_generate_module(monkeypatch, tmp_path):
+    os.environ["OPENAI_API_KEY"] = "test"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    import sys
+    if "modules" in sys.modules:
+        monkeypatch.delitem(sys.modules, "modules")
+
+    mg = importlib.import_module("modules.module_generator")
+    path = mg.generate_module("prints hello", name="demo_mod")
+    assert path.endswith("demo_mod.py")
+    assert os.path.exists(path)
+
+    reg = ModuleRegistry().auto_discover("modules")
+    assert reg.get_module("modules.demo_mod")


### PR DESCRIPTION
## Summary
- add `module_generator` module that generates new modules via Codex
- test the new module with dummy Codex client and dummy requests module

## Testing
- `ruff check modules/module_generator.py tests/test_module_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a171d6a8832496141974718ce936