### PR TITLE
Fix macro recording without pyautogui.record

### DIFF
--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -270,10 +270,11 @@ class ScreenViewer(tk.Toplevel):
         if self._after_id:
             self.after_cancel(self._after_id)
 
+        from modules.automation_learning import record_events
+
         def _rec():
             try:
-                import pyautogui
-                self.recorded_events = pyautogui.record()
+                self.recorded_events = record_events()
             except Exception:
                 self.recorded_events = []
             finally:
@@ -295,8 +296,8 @@ class ScreenViewer(tk.Toplevel):
         if self.recording or not self.recorded_events:
             return
         try:
-            import pyautogui
-            pyautogui.play(self.recorded_events)
+            from modules.automation_learning import play_events
+            play_events(self.recorded_events)
         except Exception:
             pass
 

--- a/modules/gui_recorder.py
+++ b/modules/gui_recorder.py
@@ -4,9 +4,12 @@ try:
     import tkinter as tk
     from tkinter import messagebox
     import pyautogui
+    from .automation_learning import record_events, play_events
 except Exception as e:  # pragma: no cover - optional deps
     tk = None
     pyautogui = None
+    record_events = None
+    play_events = None
     _IMPORT_ERROR = e
 else:
     _IMPORT_ERROR = None
@@ -21,7 +24,9 @@ def record_gui(name: str) -> str:
     """Record actions until ESC is pressed and save to a JSON file."""
     if _IMPORT_ERROR:
         return f"pyautogui not available: {_IMPORT_ERROR}"
-    events = pyautogui.record()
+    if record_events is None:
+        return "Recording functions unavailable"
+    events = record_events()
     import json
     import os
     os.makedirs(MACRO_DIR, exist_ok=True)
@@ -35,6 +40,8 @@ def play_gui(name: str) -> str:
     """Play back a recorded macro by name."""
     if _IMPORT_ERROR:
         return f"pyautogui not available: {_IMPORT_ERROR}"
+    if play_events is None:
+        return "Playback functions unavailable"
     import json
     import os
     path = os.path.join(MACRO_DIR, f"{name}.json")
@@ -42,7 +49,7 @@ def play_gui(name: str) -> str:
         return f"Macro '{name}' not found"
     with open(path, "r", encoding="utf-8") as f:
         events = json.load(f)
-    pyautogui.play(events)
+    play_events(events)
     return f"Played {name}"
 
 
@@ -65,4 +72,4 @@ def open_recorder_window():
 
 
 def get_description() -> str:
-    return "GUI to record pyautogui actions and save them as macros."
+    return "GUI to record desktop actions and save them as macros."

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,6 +147,7 @@ pyasn1==0.6.1
 pyasn1_modules==0.4.2
 PyAudio==0.2.14
 PyAutoGUI==0.9.54
+pynput==1.8.1
 pybase64==1.4.1
 pycaw==20240210
 pycparser==2.22

--- a/tests/test_automation_learning.py
+++ b/tests/test_automation_learning.py
@@ -40,3 +40,24 @@ def test_record_macro_script(tmp_path, monkeypatch):
     assert (macro_dir / 'demo2.json').exists()
     text = Path(path).read_text()
     assert 'pyautogui.play' in text
+
+
+def test_record_macro_no_record_attr(tmp_path, monkeypatch):
+    """Ensure fallback recorder works when pyautogui lacks record()."""
+    mod = importlib.import_module('modules.automation_learning')
+    fake_pa = types.SimpleNamespace()
+    monkeypatch.setattr(mod, 'pyautogui', fake_pa)
+    monkeypatch.setattr(mod, '_IMPORT_ERROR', None)
+    # Replace fallback recorder with stub
+    monkeypatch.setattr(mod, 'record_events', lambda: [{'z': 3}])
+    monkeypatch.setattr(mod, 'play_events', lambda ev: None)
+
+    macro_dir = tmp_path / 'macros'
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod, 'MACRO_DIR', str(macro_dir))
+
+    path = mod.record_macro('demo3')
+    assert Path(path).exists()
+    assert json.load(open(path)) == [{'z': 3}]
+    result = mod.play_macro('demo3')
+    assert 'Played macro' in result


### PR DESCRIPTION
## Summary
- add pynput dependency
- implement robust fallback record/play in automation_learning
- update GUI recorder and assistant to use new helpers
- add regression test for missing `pyautogui.record`

## Testing
- `ruff check .`
- `pytest -k automation_learning -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a3e04a7883249d28f0cafefaacda