### PR TITLE
Fix long line in assistant

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -653,7 +653,12 @@ def process_input(user_input, output_widget):
                 return
 
             # === Codex module scaffolding ===
-            m = re.match(r"(?:codex create module|scaffold code|create module|generate module) (\w+)(?:\s+(.*))?", text, re.IGNORECASE)
+            m = re.match(
+                r"(?:codex create module|scaffold code|create module|generate module)"
+                r" (\w+)(?:\s+(.*))?",
+                text,
+                re.IGNORECASE,
+            )
             if m:
                 mod_name, desc = m.groups()
                 desc = desc or ""


### PR DESCRIPTION
## Summary
- resolve E501 line too long in `assistant.py`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a8b6545c832497ec8de071613d44