### PR TITLE
Add window moving to monitor capability

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -526,6 +526,17 @@ def process_input(user_input, output_widget):
                 last_ai_response = msg
                 return
 
+            m = re.match(r"move (.+?) to (?:monitor|screen) (\d+)", text, re.IGNORECASE)
+            if m:
+                title, mon = m.group(1).strip(), int(m.group(2))
+                success, msg = window_tools.move_window_to_monitor(title, mon)
+                output_widget.insert("end", f"[Action] {msg}\n")
+                output_widget.see("end")
+                speak(msg)
+                last_ai_response = msg
+                result[0] = msg
+                return
+
             # === Casual conversation ===
             if is_chitchat(text):
                 result[0] = talk_to_llm(text)

--- a/modules/window_tools.py
+++ b/modules/window_tools.py
@@ -17,12 +17,14 @@ import platform
 import subprocess
 import ctypes
 from ctypes import wintypes
+from modules import vision_tools
 
 __all__ = [
     "focus_window",
     "minimize_window",
     "list_windows",
     "move_window",
+    "move_window_to_monitor",
     "list_open_windows",
     "list_taskbar_windows",
     "close_taskbar_item",
@@ -153,6 +155,26 @@ def move_window(title, x, y):
     win.moveTo(x, y)
     return True, f"Moved '{title}' to ({x}, {y})"
 
+
+def move_window_to_monitor(title: str, monitor: int) -> tuple[bool, str]:
+    """Move ``title`` window to the top-left corner of ``monitor``."""
+    if _IMPORT_ERROR:
+        return False, f"pygetwindow not available: {_IMPORT_ERROR}"
+    monitors = vision_tools.get_monitors()
+    if monitor < 0 or monitor >= len(monitors):
+        return False, f"Monitor {monitor} not found"
+    matches = gw.getWindowsWithTitle(title)
+    if not matches:
+        return False, f"Window '{title}' not found"
+    win = matches[0]
+    x = monitors[monitor].x
+    y = monitors[monitor].y
+    try:
+        win.moveTo(x, y)
+        return True, f"Moved '{title}' to monitor {monitor}"
+    except Exception as e:  # pragma: no cover - OS specific
+        return False, f"Failed to move '{title}' to monitor {monitor}: {e}"
+
 def minimize_window(partial_title: str):
     """Minimize the first window containing ``partial_title`` in its title."""
     if _IMPORT_ERROR:
@@ -207,6 +229,7 @@ def get_info():
             "minimize_window",
             "list_windows",
             "move_window",
+            "move_window_to_monitor",
             "list_taskbar_windows",
             "close_taskbar_item",
         ]
@@ -217,5 +240,6 @@ def get_description() -> str:
     """Return a short summary of this module."""
     return (
         "Utilities for listing taskbar windows, focusing them, moving or "
-        "minimizing windows, and closing by index."
+        "minimizing windows, relocating them between monitors, and closing "
+        "by index."
     )

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -126,6 +126,22 @@ def _handle_minimize_alias(text: str) -> str | None:
         return f"Error running minimize_window: {e}"
 
 
+def _handle_move_window_alias(text: str) -> str | None:
+    """Support ``move <title> to monitor N`` commands."""
+    m = re.match(r"move\s+(.+?)\s+(?:to|onto)\s+(?:monitor|screen)\s+(\d+)", text, re.IGNORECASE)
+    if not m:
+        return None
+    title, idx = m.groups()
+    if "move_window_to_monitor" not in ALLOWED_FUNCTIONS:
+        return talk_to_llm(text)
+    func = ALLOWED_FUNCTIONS["move_window_to_monitor"]
+    try:
+        success, msg = func(title, int(idx))
+        return msg
+    except Exception as e:
+        return f"Error running move_window_to_monitor: {e}"
+
+
 def _execute_tool_call(fn_name: str, args: str, user_text: str) -> str:
     """Validate and execute a tool call returned by the LLM."""
     if fn_name not in ALLOWED_FUNCTIONS:
@@ -180,6 +196,7 @@ def parse_and_execute(user_text: str) -> str:
         _handle_run_skill,
         _handle_terminate_alias,
         _handle_minimize_alias,
+        _handle_move_window_alias,
     ):
         result = handler(user_text)
         if result is not None:

--- a/tests/test_move_window_alias.py
+++ b/tests/test_move_window_alias.py
@@ -1,0 +1,24 @@
+import types
+import importlib
+import sys
+
+def test_parse_and_execute_move_window(monkeypatch):
+    wt = types.ModuleType('modules.window_tools')
+    calls = {}
+    def fake_move(title, idx):
+        calls['title'] = title
+        calls['idx'] = idx
+        return True, 'done'
+    wt.move_window_to_monitor = fake_move
+    wt.__all__ = ['move_window_to_monitor']
+    monkeypatch.setitem(sys.modules, 'modules.window_tools', wt)
+
+    stub_assistant = types.ModuleType('assistant')
+    stub_assistant.talk_to_llm = lambda text: 'ignored'
+    monkeypatch.setitem(sys.modules, 'assistant', stub_assistant)
+
+    orch = importlib.reload(importlib.import_module('orchestrator'))
+
+    result = orch.parse_and_execute('move spotify to monitor 1')
+    assert result == 'done'
+    assert calls == {'title': 'spotify', 'idx': 1}

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -64,3 +64,14 @@ def test_process_input_move_mouse(monkeypatch):
     assistant.set_listening(True)
     assistant.process_input('move mouse to 10 20', DummyWidget())
     assert moved == [(10, 20)]
+
+
+def test_process_input_move_window(monkeypatch):
+    assistant, _ = import_assistant(monkeypatch)
+    monkeypatch.setattr(assistant, 'speak', lambda *a, **kw: None)
+    wt = importlib.import_module('modules.window_tools')
+    calls = []
+    monkeypatch.setattr(wt, 'move_window_to_monitor', lambda t, m: calls.append((t, m)) or (True, 'ok'))
+    assistant.set_listening(True)
+    assistant.process_input('move chrome to monitor 2', DummyWidget())
+    assert calls == [('chrome', 2)]

--- a/tests/test_window_tools.py
+++ b/tests/test_window_tools.py
@@ -39,3 +39,43 @@ def test_minimize_window_success(monkeypatch):
     assert ok
     assert events.get('min')
     assert 'My App' in msg
+
+
+def test_move_window_to_monitor(monkeypatch):
+    wt = importlib.import_module('modules.window_tools')
+    vt = importlib.import_module('modules.vision_tools')
+
+    class FakeWin:
+        def __init__(self, title):
+            self.title = title
+        def moveTo(self, x, y):
+            self.moved = (x, y)
+
+    fake_gw = type('GW', (), {
+        'getWindowsWithTitle': lambda t: [FakeWin(t)]
+    })
+    monkeypatch.setattr(wt, 'gw', fake_gw)
+    monkeypatch.setattr(wt, '_IMPORT_ERROR', None)
+    monitors = [
+        type('M', (), {'x': 0, 'y': 0})(),
+        type('M', (), {'x': 100, 'y': 0})(),
+    ]
+    monkeypatch.setattr(vt, 'get_monitors', lambda: monitors)
+
+    ok, msg = wt.move_window_to_monitor('test', 1)
+    assert ok
+    assert 'monitor 1' in msg
+
+
+def test_move_window_to_monitor_invalid(monkeypatch):
+    wt = importlib.import_module('modules.window_tools')
+    vt = importlib.import_module('modules.vision_tools')
+
+    fake_gw = type('GW', (), {'getWindowsWithTitle': lambda t: []})
+    monkeypatch.setattr(wt, 'gw', fake_gw)
+    monkeypatch.setattr(wt, '_IMPORT_ERROR', None)
+    monkeypatch.setattr(vt, 'get_monitors', lambda: [])
+
+    ok, msg = wt.move_window_to_monitor('missing', 2)
+    assert not ok
+    assert 'not found' in msg.lower()


### PR DESCRIPTION
## Summary
- extend `window_tools` with `move_window_to_monitor` for multi-monitor setups
- support `move <title> to monitor <n>` in both assistant and orchestrator
- test new functionality and alias

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882b111a6548324b732d689f43f194d