### PR TITLE
Add window typing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Close or terminate apps by window title or process name (e.g. "terminate Rocket League")**
 - **List open windows via the taskbar (e.g. "what windows are open?")**
 - **Minimize windows by title (e.g. "minimize YouTube Music")**
+- **Type text into any focused window (e.g. "open notepad and type hello")**
 - **Control music playback with media keys (play/pause, skip) using keyboard, Windows API, or pyautogui fallbacks**
 - **Automatic multi-command parsing:** say "play music and open Rocket League" to run tasks one after another
 - **Tutorial mode:** ask "what does `function_name` do?" to hear documentation

--- a/modules/window_tools.py
+++ b/modules/window_tools.py
@@ -28,6 +28,7 @@ __all__ = [
     "close_taskbar_item",
     "click_ui_element",
     "learn_new_button",
+    "type_in_window",
 ]
 
 def _windows_fallback() -> list[str]:
@@ -198,6 +199,32 @@ def learn_new_button(app, action, speak):
     print(f"Saved as {filename}")
     return filename
 
+def type_in_window(title: str, text: str, offset_x: int = 100, offset_y: int = 100):
+    """Focus the first window matching ``title`` and type ``text`` inside.
+
+    The function attempts to click at ``offset_x``/``offset_y`` relative to the
+    window's top-left corner to ensure a text field is active before typing.
+    """
+    if _IMPORT_ERROR:
+        return False, f"pygetwindow not available: {_IMPORT_ERROR}"
+    if _PYAUTOGUI_ERROR:
+        return False, f"pyautogui not available: {_PYAUTOGUI_ERROR}"
+    matches = [w for w in gw.getAllTitles() if title.lower() in w.lower()]
+    if not matches:
+        return False, f"No window found containing '{title}'"
+    win = gw.getWindowsWithTitle(matches[0])[0]
+    try:
+        win.activate()
+    except Exception:
+        pass
+    time.sleep(0.5)
+    try:
+        pyautogui.click(win.left + offset_x, win.top + offset_y)
+        pyautogui.write(text, interval=0.05)
+        return True, f"Typed into '{matches[0]}'"
+    except Exception as e:  # pragma: no cover - GUI interaction failure
+        return False, f"Failed to type into '{matches[0]}': {e}"
+
 def get_info():
     return {
         "name": "window_tools",
@@ -209,6 +236,7 @@ def get_info():
             "move_window",
             "list_taskbar_windows",
             "close_taskbar_item",
+            "type_in_window",
         ]
     }
 
@@ -216,6 +244,6 @@ def get_info():
 def get_description() -> str:
     """Return a short summary of this module."""
     return (
-        "Utilities for listing taskbar windows, focusing them, moving or "
-        "minimizing windows, and closing by index."
+        "Utilities for listing taskbar windows, focusing or typing into them, "
+        "moving or minimizing windows, and closing by index."
     )

--- a/tests/test_window_tools.py
+++ b/tests/test_window_tools.py
@@ -1,4 +1,5 @@
 import importlib
+import types
 from modules.window_tools import close_taskbar_item, minimize_window
 
 def test_invalid_index():
@@ -39,3 +40,53 @@ def test_minimize_window_success(monkeypatch):
     assert ok
     assert events.get('min')
     assert 'My App' in msg
+
+
+def test_type_in_window_not_found(monkeypatch):
+    wt = importlib.import_module('modules.window_tools')
+    fake_gw = type('GW', (), {"getAllTitles": lambda: []})
+    monkeypatch.setattr(wt, 'gw', fake_gw)
+    monkeypatch.setattr(wt, '_IMPORT_ERROR', None)
+    monkeypatch.setattr(wt, '_PYAUTOGUI_ERROR', None)
+    ok, msg = wt.type_in_window('foo', 'bar')
+    assert not ok
+    assert 'No window found' in msg
+
+
+def test_type_in_window_success(monkeypatch):
+    wt = importlib.import_module('modules.window_tools')
+
+    events = {}
+
+    class FakeWin:
+        def __init__(self, title):
+            self.title = title
+            self.left = 10
+            self.top = 20
+
+        def activate(self):
+            events['activated'] = True
+
+    fake_gw = type('GW', (), {
+        'getAllTitles': lambda: ['Demo'],
+        'getWindowsWithTitle': lambda t: [FakeWin(t)],
+    })
+
+    class FakePA:
+        def click(self, x, y):
+            events['click'] = (x, y)
+
+        def write(self, text, interval=0):
+            events['text'] = text
+
+    monkeypatch.setattr(wt, 'gw', fake_gw)
+    monkeypatch.setattr(wt, 'pyautogui', FakePA())
+    monkeypatch.setattr(wt, '_IMPORT_ERROR', None)
+    monkeypatch.setattr(wt, '_PYAUTOGUI_ERROR', None)
+    monkeypatch.setattr(wt, 'time', types.SimpleNamespace(sleep=lambda s: None))
+
+    ok, msg = wt.type_in_window('demo', 'hello')
+    assert ok
+    assert events['click'] == (110, 120)
+    assert events['text'] == 'hello'
+    assert 'Typed into' in msg


### PR DESCRIPTION
## Summary
- add `type_in_window` helper to `window_tools`
- document typing automation feature in README
- test new function in `test_window_tools`

## Testing
- `python -m flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882b5eef25c83248953a242b5bb91fa