### PR TITLE
Add save and exit module

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Close or terminate apps by window title or process name (e.g. "terminate Rocket League")**
 - **List open windows via the taskbar (e.g. "what windows are open?")**
 - **Minimize windows by title (e.g. "minimize YouTube Music")**
+- **Save and exit windows by title (e.g. "save and exit Notepad")**
 - **Control music playback with media keys (play/pause, skip) using keyboard, Windows API, or pyautogui fallbacks**
 - **Automatic multi-command parsing:** say "play music and open Rocket League" to run tasks one after another
 - **Tutorial mode:** ask "what does `function_name` do?" to hear documentation

--- a/modules/save_exit.py
+++ b/modules/save_exit.py
@@ -1,0 +1,131 @@
+"""Automated save and exit functionality for application windows."""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+import time
+
+try:
+    import pygetwindow as gw
+    _GW_ERROR = None
+except Exception as e:  # pragma: no cover - optional dependency
+    gw = None
+    _GW_ERROR = e
+
+try:
+    import pyautogui
+    _PYAUTOGUI_ERROR = None
+except Exception as e:  # pragma: no cover - optional dependency
+    pyautogui = None
+    _PYAUTOGUI_ERROR = e
+
+from error_logger import log_error
+
+__all__ = ["save_and_exit", "get_info", "get_description"]
+
+MODULE_NAME = "save_exit"
+
+
+def _find_window(title: str):
+    """Return the first window containing ``title`` or ``None``."""
+    if gw is None or _GW_ERROR:
+        return None
+    matches = [w for w in gw.getAllWindows() if title.lower() in w.title.lower()]
+    return matches[0] if matches else None
+
+
+def _close_window(win) -> tuple[bool, str]:
+    """Attempt to close ``win`` using three strategies."""
+    try:
+        win.activate()
+        time.sleep(0.2)
+    except Exception:
+        pass
+
+    # 1) Native close()
+    try:
+        win.close()
+        time.sleep(0.5)
+        if win not in gw.getAllWindows():
+            return True, f"Closed window '{win.title}'"
+    except Exception:
+        pass
+
+    # 2) Alt+F4 fallback
+    try:
+        win.activate()
+        if pyautogui:
+            pyautogui.hotkey("alt", "f4")
+            time.sleep(0.5)
+            if win not in gw.getAllWindows():
+                return True, f"Closed window '{win.title}' via Alt+F4"
+    except Exception:
+        pass
+
+    # 3) OS kill as last resort
+    try:
+        title = win.title
+        if platform.system() == "Windows":
+            subprocess.run(
+                ["taskkill", "/FI", f"WINDOWTITLE eq {title}", "/T", "/F"],
+                check=True,
+            )
+        else:
+            subprocess.run(["pkill", "-f", title], check=True)
+        return True, f"Killed process for '{title}'"
+    except Exception as e:
+        return False, f"All close attempts failed for '{win.title}': {e}"
+
+
+def save_and_exit(window_title: str) -> str:
+    """Save and close the window matching ``window_title``."""
+    if _GW_ERROR:
+        return f"pygetwindow not available: {_GW_ERROR}"
+    if _PYAUTOGUI_ERROR:
+        return f"pyautogui not available: {_PYAUTOGUI_ERROR}"
+
+    win = _find_window(window_title)
+    if not win:
+        return f"Window '{window_title}' not found"
+
+    try:
+        win.activate()
+    except Exception:
+        pass
+    time.sleep(0.3)
+
+    save_steps = [
+        lambda: pyautogui.hotkey("ctrl", "s"),
+        lambda: (pyautogui.hotkey("alt", "f"), pyautogui.press("s")),
+        lambda: (pyautogui.hotkey("ctrl", "shift", "s"), pyautogui.press("enter")),
+        lambda: (pyautogui.press("f10"), pyautogui.press("s")),
+        lambda: (pyautogui.press("f10"), pyautogui.press("a"), pyautogui.press("enter")),
+    ]
+
+    saved = False
+    for step in save_steps:
+        try:
+            step()
+            time.sleep(0.4)
+            saved = True
+            break
+        except Exception as e:  # pragma: no cover - log errors
+            log_error(f"[{MODULE_NAME}] save attempt failed: {e}")
+
+    close_success, close_msg = _close_window(win)
+    status = "Saved" if saved else "Attempted to save"
+    return f"{status}; {close_msg}"
+
+
+def get_info() -> dict:
+    return {
+        "name": MODULE_NAME,
+        "description": "Try multiple strategies to save a window then close it.",
+        "functions": ["save_and_exit"],
+    }
+
+
+def get_description() -> str:
+    """Return a short summary of this module."""
+    return "Save the given window using several hotkeys and then close it."

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -126,6 +126,21 @@ def _handle_minimize_alias(text: str) -> str | None:
         return f"Error running minimize_window: {e}"
 
 
+def _handle_save_exit_alias(text: str) -> str | None:
+    """Support ``save and exit <window>`` as alias for ``save_and_exit``."""
+    m = re.match(r"\bsave and exit\s+(.+)", text, re.IGNORECASE)
+    if not m:
+        return None
+    target = m.group(1)
+    if "save_and_exit" not in ALLOWED_FUNCTIONS:
+        return talk_to_llm(text)
+    func = ALLOWED_FUNCTIONS["save_and_exit"]
+    try:
+        return func(target)
+    except Exception as e:
+        return f"Error running save_and_exit: {e}"
+
+
 def _execute_tool_call(fn_name: str, args: str, user_text: str) -> str:
     """Validate and execute a tool call returned by the LLM."""
     if fn_name not in ALLOWED_FUNCTIONS:
@@ -180,6 +195,7 @@ def parse_and_execute(user_text: str) -> str:
         _handle_run_skill,
         _handle_terminate_alias,
         _handle_minimize_alias,
+        _handle_save_exit_alias,
     ):
         result = handler(user_text)
         if result is not None:

--- a/tests/test_save_exit_alias.py
+++ b/tests/test_save_exit_alias.py
@@ -1,0 +1,26 @@
+import importlib
+import types
+import sys
+
+
+def test_parse_and_execute_save_exit(monkeypatch):
+    mod = types.ModuleType('modules.save_exit')
+    calls = {}
+
+    def fake_save_exit(title):
+        calls['title'] = title
+        return f'saved and closed {title}'
+
+    mod.save_and_exit = fake_save_exit
+    mod.__all__ = ['save_and_exit']
+    monkeypatch.setitem(sys.modules, 'modules.save_exit', mod)
+
+    stub_assistant = types.ModuleType('assistant')
+    stub_assistant.talk_to_llm = lambda t: 'ignored'
+    monkeypatch.setitem(sys.modules, 'assistant', stub_assistant)
+
+    orch = importlib.reload(importlib.import_module('orchestrator'))
+
+    result = orch.parse_and_execute('save and exit notepad')
+    assert result == 'saved and closed notepad'
+    assert calls['title'] == 'notepad'


### PR DESCRIPTION
## Summary
- add new `save_exit` module implementing robust save and close functionality
- support `save and exit <window>` command via orchestrator alias
- document new capability in README
- test alias handling

## Testing
- `pytest tests/test_save_exit_alias.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6882b6669ad4832491b8f23f47b87822