### PR TITLE
Add window text entry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Close or terminate apps by window title or process name (e.g. "terminate Rocket League")**
 - **List open windows via the taskbar (e.g. "what windows are open?")**
 - **Minimize windows by title (e.g. "minimize YouTube Music")**
+- **Type text into any window by title (e.g. "type hello in Notepad")**
 - **Control music playback with media keys (play/pause, skip) using keyboard, Windows API, or pyautogui fallbacks**
 - **Automatic multi-command parsing:** say "play music and open Rocket League" to run tasks one after another
 - **Tutorial mode:** ask "what does `function_name` do?" to hear documentation

--- a/modules/window_tools.py
+++ b/modules/window_tools.py
@@ -30,6 +30,7 @@ __all__ = [
     "close_taskbar_item",
     "click_ui_element",
     "learn_new_button",
+    "type_in_window",
 ]
 
 def _windows_fallback() -> list[str]:
@@ -189,6 +190,25 @@ def minimize_window(partial_title: str):
     except Exception as e:  # pragma: no cover - OS specific
         return False, f"Failed to minimize '{matches[0]}': {e}"
 
+def type_in_window(partial_title: str, text: str) -> tuple[bool, str]:
+    """Focus ``partial_title`` window and type ``text`` into it."""
+    if _IMPORT_ERROR or _PYAUTOGUI_ERROR:
+        return False, "pygetwindow or pyautogui not available"
+    matches = [w for w in gw.getAllTitles() if partial_title.lower() in w.lower()]
+    if not matches:
+        return False, f"No window found containing '{partial_title}'"
+    win = gw.getWindowsWithTitle(matches[0])[0]
+    try:
+        win.activate()
+        time.sleep(0.5)
+    except Exception:
+        pass
+    try:
+        pyautogui.write(text, interval=0.05)
+        return True, f"Typed text into '{matches[0]}'"
+    except Exception as e:  # pragma: no cover - pyautogui failures
+        return False, f"Failed to type in '{matches[0]}': {e}"
+
 def list_windows():
     """Alias for list_open_windows for API consistency."""
     return list_open_windows()
@@ -232,6 +252,7 @@ def get_info():
             "move_window_to_monitor",
             "list_taskbar_windows",
             "close_taskbar_item",
+            "type_in_window",
         ]
     }
 
@@ -240,6 +261,6 @@ def get_description() -> str:
     """Return a short summary of this module."""
     return (
         "Utilities for listing taskbar windows, focusing them, moving or "
-        "minimizing windows, relocating them between monitors, and closing "
-        "by index."
+        "minimizing windows, relocating them between monitors, typing into "
+        "a window, and closing by index."
     )

--- a/tests/test_window_tools.py
+++ b/tests/test_window_tools.py
@@ -1,4 +1,5 @@
 import importlib
+import types
 from modules.window_tools import close_taskbar_item, minimize_window
 
 def test_invalid_index():
@@ -79,3 +80,29 @@ def test_move_window_to_monitor_invalid(monkeypatch):
     ok, msg = wt.move_window_to_monitor('missing', 2)
     assert not ok
     assert 'not found' in msg.lower()
+
+
+def test_type_in_window(monkeypatch):
+    wt = importlib.import_module('modules.window_tools')
+
+    class FakeWin:
+        def __init__(self, title):
+            self.title = title
+        def activate(self):
+            pass
+
+    fake_gw = types.SimpleNamespace(
+        getAllTitles=lambda: ['Notepad'],
+        getWindowsWithTitle=lambda t: [FakeWin(t)]
+    )
+    typed = []
+    fake_pg = types.SimpleNamespace(write=lambda text, interval=0.05: typed.append(text))
+    monkeypatch.setattr(wt, 'gw', fake_gw)
+    monkeypatch.setattr(wt, 'pyautogui', fake_pg)
+    monkeypatch.setattr(wt, '_IMPORT_ERROR', None)
+    monkeypatch.setattr(wt, '_PYAUTOGUI_ERROR', None)
+
+    ok, msg = wt.type_in_window('notepad', 'hello')
+    assert ok
+    assert typed == ['hello']
+    assert 'notepad' in msg.lower()


### PR DESCRIPTION
## Summary
- add `type_in_window` helper to focus a window and type text
- document typing capability in README
- test new helper

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882bd0d7f348324a879031f4b3b0413