### PR TITLE
Add save_and_exit module with CLI/voice alias

### DIFF
--- a/modules/save_exit.py
+++ b/modules/save_exit.py
@@ -1,0 +1,109 @@
+"""Attempt to save then close a window using multiple strategies."""
+
+from __future__ import annotations
+
+import subprocess
+import platform
+import time
+
+try:
+    import pygetwindow as gw
+    import pyautogui
+except Exception as e:  # pragma: no cover - optional dependency
+    gw = None
+    pyautogui = None
+    _IMPORT_ERROR = e
+else:
+    _IMPORT_ERROR = None
+
+__all__ = ["save_and_exit", "get_description"]
+
+
+def _find_window(title: str):
+    """Return the first window matching ``title`` or ``None``."""
+    if gw is None or _IMPORT_ERROR:
+        return None
+    matches = gw.getWindowsWithTitle(title)
+    return matches[0] if matches else None
+
+
+def _send_hotkey(*keys):
+    """Send a hotkey if pyautogui is available."""
+    if pyautogui:
+        try:
+            pyautogui.hotkey(*keys)
+            time.sleep(0.3)
+        except Exception:
+            pass
+
+
+def _kill_process_for_window(win) -> bool:
+    """Kill the process owning ``win``."""
+    try:
+        title = win.title
+        if platform.system() == "Windows":
+            subprocess.run([
+                "taskkill",
+                "/FI",
+                f"WINDOWTITLE eq {title}",
+                "/T",
+                "/F",
+            ], check=True)
+        else:
+            subprocess.run(["pkill", "-f", title], check=True)
+        return True
+    except Exception:
+        return False
+
+
+def save_and_exit(title: str) -> str:
+    """Attempt to save and then close the window ``title``.
+
+    Five saving strategies are attempted before giving up. After the save
+    attempts, three close strategies try to close the same window.
+
+    Parameters
+    ----------
+    title:
+        Partial title of the target window.
+
+    Returns
+    -------
+    str
+        Message describing the outcome.
+    """
+
+    if _IMPORT_ERROR:
+        return f"Missing dependency: {_IMPORT_ERROR}"
+
+    win = _find_window(title)
+    if win is None:
+        return f"Window '{title}' not found"
+
+    win.activate()
+    save_attempts = [
+        lambda: _send_hotkey("ctrl", "s"),
+        lambda: _send_hotkey("ctrl", "shift", "s"),
+        lambda: (_send_hotkey("alt", "f"), _send_hotkey("s")),
+        lambda: (_send_hotkey("alt", "f"), _send_hotkey("a"), _send_hotkey("enter")),
+        lambda: _send_hotkey("ctrl", "s"),
+    ]
+    for attempt in save_attempts:
+        attempt()
+        time.sleep(0.2)
+    close_attempts = [
+        lambda: getattr(win, "close", lambda: None)(),
+        lambda: _send_hotkey("alt", "f4"),
+        lambda: _kill_process_for_window(win),
+    ]
+    for attempt in close_attempts:
+        attempt()
+        time.sleep(0.3)
+        if win not in gw.getAllWindows():
+            return f"Saved and closed '{win.title}'"
+    return f"Save attempts done; window may still be open"
+
+
+def get_description() -> str:
+    """Return a short summary of this module."""
+    return "Save a window using common shortcuts then close it robustly."

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -142,6 +142,21 @@ def _handle_move_window_alias(text: str) -> str | None:
         return f"Error running move_window_to_monitor: {e}"
 
 
+def _handle_save_exit_alias(text: str) -> str | None:
+    """Support ``save and exit <window>`` commands."""
+    m = re.match(r"save and exit\s+(.+)", text, re.IGNORECASE)
+    if not m:
+        return None
+    target = m.group(1)
+    if "save_and_exit" not in ALLOWED_FUNCTIONS:
+        return talk_to_llm(text)
+    func = ALLOWED_FUNCTIONS["save_and_exit"]
+    try:
+        return func(target)
+    except Exception as e:
+        return f"Error running save_and_exit: {e}"
+
+
 def _execute_tool_call(fn_name: str, args: str, user_text: str) -> str:
     """Validate and execute a tool call returned by the LLM."""
     if fn_name not in ALLOWED_FUNCTIONS:
@@ -197,6 +212,7 @@ def parse_and_execute(user_text: str) -> str:
         _handle_terminate_alias,
         _handle_minimize_alias,
         _handle_move_window_alias,
+        _handle_save_exit_alias,
     ):
         result = handler(user_text)
         if result is not None:

--- a/tests/test_save_exit_alias.py
+++ b/tests/test_save_exit_alias.py
@@ -1,0 +1,24 @@
+import importlib
+import types
+import sys
+
+
+def test_parse_and_execute_save_exit(monkeypatch):
+    mod = types.ModuleType('modules.save_exit')
+    called = {}
+    def fake_save_and_exit(title):
+        called['title'] = title
+        return f"closed {title}"
+    mod.save_and_exit = fake_save_and_exit
+    mod.__all__ = ['save_and_exit']
+    monkeypatch.setitem(sys.modules, 'modules.save_exit', mod)
+
+    stub_assistant = types.ModuleType('assistant')
+    stub_assistant.talk_to_llm = lambda t: 'ignored'
+    monkeypatch.setitem(sys.modules, 'assistant', stub_assistant)
+
+    orch = importlib.reload(importlib.import_module('orchestrator'))
+
+    result = orch.parse_and_execute('save and exit notepad')
+    assert result == 'closed notepad'
+    assert called['title'] == 'notepad'


### PR DESCRIPTION
## Summary
- implement `save_and_exit` module for saving and closing windows
- expose alias `save and exit <window>` in `orchestrator.parse_and_execute`
- add unit test for the new alias

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c09699ec8324a424f522d031c14f