### PR TITLE
Add Windows system volume control

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -332,19 +332,40 @@ def process_input(user_input, output_widget):
                 return
 
             # === Volume commands ===
-            m = re.search(
-                r"set (?:speech |voice )?volume to ([0-9]*\.?[0-9]+)", text.lower()
-            )
+            m = re.search(r"set (?:system )?volume(?: to)? ([0-9]*\.?[0-9]+)", text.lower())
             if m:
                 val = float(m.group(1))
-                from modules import tts_integration
+                if val > 1:
+                    from modules import system_volume
 
-                ok = tts_integration.set_volume(val)
-                msg = (
-                    f"Volume set to {val}"
-                    if ok is True
-                    else "Invalid volume. Use 0.0 to 1.0"
-                )
+                    msg = system_volume.set_volume(int(val))
+                else:
+                    from modules import tts_integration
+
+                    ok = tts_integration.set_volume(val)
+                    msg = (
+                        f"Volume set to {val}"
+                        if ok is True
+                        else "Invalid volume. Use 0.0 to 1.0"
+                    )
+                output_widget.insert("end", f"Assistant: {msg}\n")
+                output_widget.see("end")
+                speak(msg)
+                last_ai_response = msg
+                return
+            if "increase system volume" in text.lower():
+                from modules import media_controls
+
+                msg = media_controls.volume_up()
+                output_widget.insert("end", f"Assistant: {msg}\n")
+                output_widget.see("end")
+                speak(msg)
+                last_ai_response = msg
+                return
+            if "decrease system volume" in text.lower() or "lower system volume" in text.lower():
+                from modules import media_controls
+
+                msg = media_controls.volume_down()
                 output_widget.insert("end", f"Assistant: {msg}\n")
                 output_widget.see("end")
                 speak(msg)

--- a/cli_assistant.py
+++ b/cli_assistant.py
@@ -14,11 +14,42 @@ import pyautogui
 import time
 import os
 
+
+def process_command(user_input: str):
+    """Return a response for basic CLI commands or ``None``."""
+    cmd = user_input.strip().lower()
+    if cmd.startswith("set volume "):
+        try:
+            value = int(cmd.split("set volume ", 1)[1])
+        except ValueError:
+            return "[Error] Invalid volume"
+        from modules import system_volume
+
+        return system_volume.set_volume(value)
+
+    if cmd in {"volume up", "increase volume"}:
+        from modules import media_controls
+
+        return media_controls.volume_up()
+
+    if cmd in {"volume down", "decrease volume"}:
+        from modules import media_controls
+
+        return media_controls.volume_down()
+
+    return None
+
 def cli_loop():
     print("Local AI Assistant with Memory\nType 'exit' to quit, 'recall <keyword>' to search memory.")
     while True:
         user_input = input("You: ").strip()
         if not user_input:
+            continue
+
+        # Simple commands like volume control
+        resp = process_command(user_input)
+        if resp is not None:
+            print("Assistant:", resp)
             continue
 
         # --- Centralized sleep/wake logic ---

--- a/modules/system_volume.py
+++ b/modules/system_volume.py
@@ -3,7 +3,12 @@
 import sys
 from ctypes import POINTER, cast
 from comtypes import CLSCTX_ALL
-from pycaw.pycaw import AudioUtilities, IAudioEndpointVolume
+from pycaw.pycaw import (
+    IAudioEndpointVolume,
+    MMDeviceEnumerator,
+    EDataFlow,
+    ERole,
+)
 
 from error_logger import log_error
 
@@ -13,11 +18,12 @@ __all__ = ["set_volume", "get_volume"]
 
 
 def _get_endpoint():
-    """Return the IAudioEndpointVolume interface."""
-    devices = AudioUtilities.GetSpeakers()
-    interface = devices.Activate(
-        IAudioEndpointVolume._iid_, CLSCTX_ALL, None
+    """Return the IAudioEndpointVolume interface for the default device."""
+    enumerator = MMDeviceEnumerator()
+    device = enumerator.GetDefaultAudioEndpoint(
+        EDataFlow.eRender, ERole.eMultimedia
     )
+    interface = device.Activate(IAudioEndpointVolume._iid_, CLSCTX_ALL, None)
     return cast(interface, POINTER(IAudioEndpointVolume))
 
 

--- a/tests/test_cli_volume.py
+++ b/tests/test_cli_volume.py
@@ -1,0 +1,36 @@
+import importlib
+import sys
+import types
+
+sys.modules.setdefault('keyboard', types.ModuleType('keyboard'))
+sys.modules.setdefault('pyautogui', types.ModuleType('pyautogui'))
+sys.modules.setdefault('comtypes', types.SimpleNamespace(CLSCTX_ALL=None))
+pycaw_stub = types.ModuleType('pycaw')
+pycaw_stub.pycaw = types.SimpleNamespace(
+    IAudioEndpointVolume=None,
+    MMDeviceEnumerator=None,
+    EDataFlow=None,
+    ERole=None,
+)
+sys.modules.setdefault('pycaw', pycaw_stub)
+sys.modules.setdefault('pycaw.pycaw', pycaw_stub.pycaw)
+
+from cli_assistant import process_command
+
+
+def test_cli_set_volume(monkeypatch):
+    sv = importlib.import_module('modules.system_volume')
+    calls = []
+    monkeypatch.setattr(sv, 'set_volume', lambda v: calls.append(v) or 'ok')
+    out = process_command('set volume 80')
+    assert calls == [80]
+    assert out == 'ok'
+
+
+def test_cli_volume_up(monkeypatch):
+    mc = importlib.import_module('modules.media_controls')
+    calls = []
+    monkeypatch.setattr(mc, 'volume_up', lambda: calls.append('up') or 'ok')
+    out = process_command('volume up')
+    assert calls == ['up']
+    assert out == 'ok'

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -1,6 +1,18 @@
 import importlib
 import types
+import sys
 from tests.test_assistant_utils import import_assistant
+
+sys.modules.setdefault('comtypes', types.SimpleNamespace(CLSCTX_ALL=None))
+pycaw_stub = types.ModuleType('pycaw')
+pycaw_stub.pycaw = types.SimpleNamespace(
+    IAudioEndpointVolume=None,
+    MMDeviceEnumerator=None,
+    EDataFlow=None,
+    ERole=None,
+)
+sys.modules.setdefault('pycaw', pycaw_stub)
+sys.modules.setdefault('pycaw.pycaw', pycaw_stub.pycaw)
 
 class DummyWidget:
     def insert(self, *a, **kw):
@@ -75,3 +87,25 @@ def test_process_input_move_window(monkeypatch):
     assistant.set_listening(True)
     assistant.process_input('move chrome to monitor 2', DummyWidget())
     assert calls == [('chrome', 2)]
+
+
+def test_process_input_set_system_volume(monkeypatch):
+    assistant, _ = import_assistant(monkeypatch)
+    monkeypatch.setattr(assistant, 'speak', lambda *a, **kw: None)
+    sv = importlib.import_module('modules.system_volume')
+    calls = []
+    monkeypatch.setattr(sv, 'set_volume', lambda v: calls.append(v) or 'ok')
+    assistant.set_listening(True)
+    assistant.process_input('set system volume to 30', DummyWidget())
+    assert calls == [30]
+
+
+def test_process_input_increase_system_volume(monkeypatch):
+    assistant, _ = import_assistant(monkeypatch)
+    monkeypatch.setattr(assistant, 'speak', lambda *a, **kw: None)
+    mc = importlib.import_module('modules.media_controls')
+    calls = []
+    monkeypatch.setattr(mc, 'volume_up', lambda: calls.append('up') or 'ok')
+    assistant.set_listening(True)
+    assistant.process_input('increase system volume', DummyWidget())
+    assert calls == ['up']

--- a/tests/test_system_volume.py
+++ b/tests/test_system_volume.py
@@ -1,0 +1,37 @@
+import importlib
+import types
+import sys
+
+sys.modules.setdefault('comtypes', types.SimpleNamespace(CLSCTX_ALL=None))
+pycaw_stub = types.ModuleType('pycaw')
+pycaw_stub.pycaw = types.SimpleNamespace(
+    IAudioEndpointVolume=None,
+    MMDeviceEnumerator=None,
+    EDataFlow=None,
+    ERole=None,
+)
+sys.modules.setdefault('pycaw', pycaw_stub)
+sys.modules.setdefault('pycaw.pycaw', pycaw_stub.pycaw)
+
+def test_set_volume(monkeypatch):
+    sv = importlib.import_module('modules.system_volume')
+    monkeypatch.setattr(sv.sys, 'platform', 'win32')
+    class EP:
+        def SetMasterVolumeLevelScalar(self, val, _):
+            self.value = val
+    ep = EP()
+    monkeypatch.setattr(sv, '_get_endpoint', lambda: ep)
+    out = sv.set_volume(40)
+    assert ep.value == 0.4
+    assert '40%' in out
+    assert sv.set_volume(150) == 'Volume must be 0-100'
+
+
+def test_get_volume(monkeypatch):
+    sv = importlib.import_module('modules.system_volume')
+    monkeypatch.setattr(sv.sys, 'platform', 'win32')
+    class EP:
+        def GetMasterVolumeLevelScalar(self):
+            return 0.7
+    monkeypatch.setattr(sv, '_get_endpoint', lambda: EP())
+    assert sv.get_volume() == 70


### PR DESCRIPTION
## Summary
- use `MMDeviceEnumerator` so system volume uses the default Windows output device
- expose a `process_command` helper in `cli_assistant` for simple commands
- parse system volume commands in `assistant`
- test new CLI and voice volume logic and underlying module

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c176697483249b8535b205f05201