### PR TITLE
Fix DALL‑E API usage

### DIFF
--- a/modules/image_generator.py
+++ b/modules/image_generator.py
@@ -16,7 +16,14 @@ MODULE_NAME = "image_generator"
 __all__ = ["generate_image", "get_info", "get_description"]
 
 
-def generate_image(prompt: str, *, provider: str = "openai", size: str = "512x512", save_dir: str = "generated_images") -> str:
+def generate_image(
+    prompt: str,
+    *,
+    provider: str = "openai",
+    model: str = "dall-e-3",
+    size: str = "512x512",
+    save_dir: str = "generated_images",
+) -> str:
     """Generate an image from ``prompt`` and save it locally.
 
     Parameters
@@ -25,8 +32,10 @@ def generate_image(prompt: str, *, provider: str = "openai", size: str = "512x51
         Text description of the desired image.
     provider:
         API provider identifier. Currently only ``"openai"`` is supported.
+    model:
+        Model identifier for the provider, e.g. ``"dall-e-3"``.
     size:
-        Image resolution string, e.g. ``"512x512"``.
+        Image resolution string (for providers that support it), e.g. ``"512x512"``.
     save_dir:
         Folder to store generated images.
 
@@ -49,6 +58,7 @@ def generate_image(prompt: str, *, provider: str = "openai", size: str = "512x51
     }
     payload = {
         "prompt": prompt,
+        "model": model,
         "n": 1,
         "size": size,
         "response_format": "b64_json",

--- a/tests/test_image_generator.py
+++ b/tests/test_image_generator.py
@@ -7,6 +7,9 @@ import pytest
 
 
 def fake_post(url, json=None, headers=None, timeout=60):
+    """Return a dummy response object and capture the payload."""
+    fake_post.last_payload = json
+
     class Dummy:
         def raise_for_status(self):
             pass
@@ -33,4 +36,5 @@ def test_generate_image(monkeypatch, tmp_path):
     result = ig.generate_image("a cat")
     assert result.endswith(".png")
     assert os.path.exists(result)
+    assert fake_post.last_payload["model"] == "dall-e-3"
 


### PR DESCRIPTION
## Summary
- update `generate_image` to pass model name when calling the OpenAI API
- assert the model payload in image generator tests

## Testing
- `ruff check modules/image_generator.py tests/test_image_generator.py`
- `flake8 modules/image_generator.py tests/test_image_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882cc9a85dc83248596d724a73d8ec1