### PR TITLE
Add Xbox Game Bar capture control module

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Focus windows by title (e.g. "focus Spotify")**
 - **Type text into any window by title (e.g. "type hello in Notepad")**
 - **Control music playback with media keys (play/pause, skip) using keyboard, Windows API, or pyautogui fallbacks**
+- **Control Xbox Game Bar capture:** open the overlay, start/stop recording, take screenshots, or capture the last 30 seconds
 - **Automatic multi-command parsing:** say "play music and open Rocket League" to run tasks one after another
 - **Tutorial mode:** ask "what does `function_name` do?" to hear documentation
 - **Emulation mode:** set `emulate_actions` to true to practice commands safely

--- a/assistant.py
+++ b/assistant.py
@@ -426,6 +426,46 @@ def process_input(user_input, output_widget):
                 last_ai_response = msg
                 return
 
+            if txt_l in ["open game bar", "open capture"]:
+                from modules import gamebar_capture
+
+                msg = gamebar_capture.open_capture()
+                output_widget.insert("end", f"Assistant: {msg}\n")
+                output_widget.see("end")
+                speak(msg)
+                last_ai_response = msg
+                return
+
+            if txt_l in ["start recording", "stop recording", "toggle recording"]:
+                from modules import gamebar_capture
+
+                msg = gamebar_capture.toggle_recording()
+                output_widget.insert("end", f"Assistant: {msg}\n")
+                output_widget.see("end")
+                speak(msg)
+                last_ai_response = msg
+                return
+
+            if txt_l in ["take screenshot", "capture screenshot"]:
+                from modules import gamebar_capture
+
+                msg = gamebar_capture.capture_screenshot()
+                output_widget.insert("end", f"Assistant: {msg}\n")
+                output_widget.see("end")
+                speak(msg)
+                last_ai_response = msg
+                return
+
+            if txt_l in ["record last 30 seconds", "capture last 30 seconds"]:
+                from modules import gamebar_capture
+
+                msg = gamebar_capture.capture_last_30s()
+                output_widget.insert("end", f"Assistant: {msg}\n")
+                output_widget.see("end")
+                speak(msg)
+                last_ai_response = msg
+                return
+
             # === Voice selection ===
             m = re.search(r"(?:use|set|change) ([\w-]+) voice", text.lower())
             if m:

--- a/cli_assistant.py
+++ b/cli_assistant.py
@@ -53,6 +53,26 @@ def process_command(user_input: str):
 
         return media_controls.volume_down()
 
+    if cmd in {"start recording", "stop recording", "toggle recording"}:
+        from modules import gamebar_capture
+
+        return gamebar_capture.toggle_recording()
+
+    if cmd in {"open game bar", "open capture"}:
+        from modules import gamebar_capture
+
+        return gamebar_capture.open_capture()
+
+    if cmd in {"take screenshot", "capture screenshot"}:
+        from modules import gamebar_capture
+
+        return gamebar_capture.capture_screenshot()
+
+    if cmd in {"record last 30 seconds", "capture last 30 seconds"}:
+        from modules import gamebar_capture
+
+        return gamebar_capture.capture_last_30s()
+
     return None
 
 

--- a/modules/gamebar_capture.py
+++ b/modules/gamebar_capture.py
@@ -1,0 +1,105 @@
+"""Control Xbox Game Bar capture widget via hotkeys."""
+
+import sys
+from error_logger import log_error
+
+try:  # optional runtime dependency
+    import keyboard
+except Exception as e:  # pragma: no cover - optional dep
+    keyboard = None
+    _IMPORT_ERROR = e
+else:  # pragma: no cover - optional dep
+    _IMPORT_ERROR = None
+
+try:  # optional fallback
+    import pyautogui
+except Exception:  # pragma: no cover - optional dep
+    pyautogui = None
+
+MODULE_NAME = "gamebar_capture"
+
+__all__ = [
+    "open_capture",
+    "toggle_recording",
+    "capture_screenshot",
+    "capture_last_30s",
+]
+
+
+def _send_combo(keys: list[str]) -> str:
+    """Send a key combination using available backends."""
+    if not sys.platform.startswith("win"):
+        return "Xbox Game Bar is only supported on Windows"
+
+    combo = "+".join(keys)
+    try:
+        if keyboard is not None:
+            keyboard.send(combo)
+            return "ok"
+        if pyautogui is not None:
+            pyautogui.hotkey(*keys)
+            return "ok"
+        return f"keyboard module missing: {_IMPORT_ERROR}"
+    except Exception as e:  # pragma: no cover - OS specific
+        log_error(f"[{MODULE_NAME}] send combo error: {e}")
+        return f"Error sending keys: {e}"
+
+
+def open_capture() -> str:
+    """Open the Xbox Game Bar overlay."""
+    result = _send_combo(["win", "g"])
+    return "Game Bar opened" if result == "ok" else result
+
+
+def toggle_recording() -> str:
+    """Start or stop screen recording."""
+    result = _send_combo(["win", "alt", "r"])
+    return "Recording toggled" if result == "ok" else result
+
+
+def capture_screenshot() -> str:
+    """Take a Game Bar screenshot."""
+    result = _send_combo(["win", "alt", "printscreen"])
+    return "Screenshot captured" if result == "ok" else result
+
+
+def capture_last_30s() -> str:
+    """Record the last 30 seconds of gameplay."""
+    result = _send_combo(["win", "alt", "g"])
+    return "Last 30 seconds captured" if result == "ok" else result
+
+
+def get_info():
+    return {
+        "name": MODULE_NAME,
+        "description": "Control Xbox Game Bar capture: open overlay, recording, screenshot.",
+        "functions": [
+            "open_capture",
+            "toggle_recording",
+            "capture_screenshot",
+            "capture_last_30s",
+        ],
+    }
+
+
+def get_description() -> str:
+    """Return a short description of this module."""
+    return "Operate the Xbox Game Bar capture widget via hotkeys."
+
+
+def register():
+    from module_manager import ModuleRegistry
+
+    ModuleRegistry.register(
+        MODULE_NAME,
+        {
+            "open_capture": open_capture,
+            "toggle_recording": toggle_recording,
+            "capture_screenshot": capture_screenshot,
+            "capture_last_30s": capture_last_30s,
+            "get_info": get_info,
+        },
+    )
+
+# register()
+

--- a/tests/test_cli_gamebar_capture.py
+++ b/tests/test_cli_gamebar_capture.py
@@ -1,0 +1,44 @@
+import importlib
+import sys
+import types
+
+sys.modules.setdefault('keyboard', types.ModuleType('keyboard'))
+sys.modules.setdefault('pyautogui', types.ModuleType('pyautogui'))
+
+from cli_assistant import process_command
+
+
+def test_cli_start_recording(monkeypatch):
+    gb = importlib.import_module('modules.gamebar_capture')
+    calls = []
+    monkeypatch.setattr(gb, 'toggle_recording', lambda: calls.append('rec') or 'ok')
+    out = process_command('start recording')
+    assert calls == ['rec']
+    assert out == 'ok'
+
+
+def test_cli_open_game_bar(monkeypatch):
+    gb = importlib.import_module('modules.gamebar_capture')
+    calls = []
+    monkeypatch.setattr(gb, 'open_capture', lambda: calls.append('open') or 'ok')
+    out = process_command('open game bar')
+    assert calls == ['open']
+    assert out == 'ok'
+
+
+def test_cli_take_screenshot(monkeypatch):
+    gb = importlib.import_module('modules.gamebar_capture')
+    calls = []
+    monkeypatch.setattr(gb, 'capture_screenshot', lambda: calls.append('shot') or 'ok')
+    out = process_command('take screenshot')
+    assert calls == ['shot']
+    assert out == 'ok'
+
+
+def test_cli_last_30s(monkeypatch):
+    gb = importlib.import_module('modules.gamebar_capture')
+    calls = []
+    monkeypatch.setattr(gb, 'capture_last_30s', lambda: calls.append('30s') or 'ok')
+    out = process_command('record last 30 seconds')
+    assert calls == ['30s']
+    assert out == 'ok'

--- a/tests/test_gamebar_capture.py
+++ b/tests/test_gamebar_capture.py
@@ -1,0 +1,45 @@
+import importlib
+import types
+
+
+def test_open_capture_keyboard(monkeypatch):
+    gb = importlib.import_module('modules.gamebar_capture')
+    events = []
+    fake_kb = types.SimpleNamespace(send=lambda combo: events.append(combo))
+    monkeypatch.setattr(gb, 'keyboard', fake_kb)
+    monkeypatch.setattr(gb, 'pyautogui', None, raising=False)
+    monkeypatch.setattr(gb.sys, 'platform', 'win32')
+    monkeypatch.setattr(gb, '_IMPORT_ERROR', None)
+    out = gb.open_capture()
+    assert events == ['win+g']
+    assert 'opened' in out.lower()
+
+
+def test_toggle_recording_pyautogui(monkeypatch):
+    gb = importlib.import_module('modules.gamebar_capture')
+    events = []
+    fake_pg = types.SimpleNamespace(hotkey=lambda *keys: events.append('+'.join(keys)))
+    monkeypatch.setattr(gb, 'keyboard', None)
+    monkeypatch.setattr(gb, 'pyautogui', fake_pg, raising=False)
+    monkeypatch.setattr(gb.sys, 'platform', 'win32')
+    monkeypatch.setattr(gb, '_IMPORT_ERROR', RuntimeError('missing'))
+    out = gb.toggle_recording()
+    assert events == ['win+alt+r']
+    assert 'toggled' in out.lower()
+
+
+def test_capture_last_30s_non_windows(monkeypatch):
+    gb = importlib.import_module('modules.gamebar_capture')
+    monkeypatch.setattr(gb.sys, 'platform', 'linux')
+    out = gb.capture_last_30s()
+    assert 'windows' in out.lower()
+
+
+def test_screenshot_no_backend(monkeypatch):
+    gb = importlib.import_module('modules.gamebar_capture')
+    monkeypatch.setattr(gb, 'keyboard', None)
+    monkeypatch.setattr(gb, 'pyautogui', None, raising=False)
+    monkeypatch.setattr(gb.sys, 'platform', 'win32')
+    monkeypatch.setattr(gb, '_IMPORT_ERROR', RuntimeError('missing'))
+    out = gb.capture_screenshot()
+    assert 'keyboard module missing' in out


### PR DESCRIPTION
## Summary
- add new `gamebar_capture` module for Xbox Game Bar hotkeys
- support Game Bar commands in CLI and voice processing
- document capability in README
- test Game Bar module and CLI integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882cde1ee0c83249ab2c598875e3ad7