### PR TITLE
Add local Stable Diffusion image generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Record and play macros on the fly for custom workflows**
 - **Hotkeys tab with a macro recorder and 3-second countdown**
 - **Vision/ocr tools:** Screen capture and image recognition by voice or command
+- **Local image generation via Stable Diffusion (no cloud required)**
 - **Home Assistant integration via REST API (disabled by default)**
 - **Plugin system:** Easy extension with your own Python modules
 - **Interactive module generator with preview and confirmation**

--- a/modules/codex_integration.py
+++ b/modules/codex_integration.py
@@ -2,7 +2,7 @@
 
 import os
 import time
-import requests
+import importlib
 
 from error_logger import log_error
 from module_manager import ModuleRegistry
@@ -63,6 +63,7 @@ class CodexClient:
                 "Content-Type": "application/json",
             }
         try:
+            requests = importlib.import_module("requests")
             resp = requests.post(self.url, json=payload, headers=headers, timeout=60)
             resp.raise_for_status()
             data = resp.json()

--- a/modules/image_generator.py
+++ b/modules/image_generator.py
@@ -6,7 +6,7 @@ import base64
 import os
 from typing import Optional
 
-import requests
+import importlib
 
 from error_logger import log_error
 from modules.api_keys import get_api_key
@@ -64,7 +64,13 @@ def generate_image(
         "response_format": "b64_json",
     }
     try:
-        resp = requests.post("https://api.openai.com/v1/images/generations", json=payload, headers=headers, timeout=60)
+        requests = importlib.import_module("requests")
+        resp = requests.post(
+            "https://api.openai.com/v1/images/generations",
+            json=payload,
+            headers=headers,
+            timeout=60,
+        )
         resp.raise_for_status()
         data = resp.json()
         b64 = data.get("data", [{}])[0].get("b64_json")

--- a/modules/stable_diffusion_generator.py
+++ b/modules/stable_diffusion_generator.py
@@ -1,0 +1,129 @@
+"""Local Stable Diffusion image generator."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+try:
+    from diffusers import StableDiffusionPipeline
+except Exception as e:  # pragma: no cover - optional dependency
+    StableDiffusionPipeline = None
+    _IMPORT_ERROR = e
+else:
+    _IMPORT_ERROR = None
+
+try:
+    import torch
+except Exception as e:  # pragma: no cover - optional dependency
+    torch = None
+    _TORCH_ERROR = e
+else:
+    _TORCH_ERROR = None
+
+
+from error_logger import log_error
+
+MODULE_NAME = "stable_diffusion_generator"
+
+__all__ = ["generate_image", "load_model", "get_info", "get_description"]
+
+
+_pipeline: Optional[StableDiffusionPipeline] = None
+_model_path: str | None = None
+
+
+def load_model(model_path: str, device: str = "cpu") -> str:
+    """Load a Stable Diffusion pipeline from ``model_path``."""
+    global _pipeline, _model_path
+    if StableDiffusionPipeline is None or torch is None:
+        return f"Missing dependencies: {_IMPORT_ERROR or _TORCH_ERROR}"
+
+    if _pipeline is not None and _model_path == model_path:
+        return "loaded"
+
+    try:
+        pipe = StableDiffusionPipeline.from_pretrained(model_path)
+        pipe = pipe.to(device)
+    except Exception as exc:  # pragma: no cover - loading may fail
+        log_error(f"[stable_diffusion_generator] load failed: {exc}")
+        return f"Failed to load model: {exc}"
+
+    _pipeline = pipe
+    _model_path = model_path
+    return "loaded"
+
+
+def generate_image(
+    prompt: str,
+    model_path: str,
+    *,
+    device: str = "cpu",
+    save_dir: str = "generated_images",
+) -> str:
+    """Generate an image using a local Stable Diffusion model.
+
+    Parameters
+    ----------
+    prompt:
+        Text prompt describing the desired image.
+    model_path:
+        Filesystem path to the Stable Diffusion weights.
+    device:
+        PyTorch device string, e.g. ``"cpu"`` or ``"cuda"``.
+    save_dir:
+        Directory to store generated images.
+
+    Returns
+    -------
+    str
+        Path to the saved image on success, otherwise an error message.
+    """
+    if StableDiffusionPipeline is None or torch is None:
+        return f"Missing dependencies: {_IMPORT_ERROR or _TORCH_ERROR}"
+
+    if load_model(model_path, device) != "loaded":
+        return f"Failed to load model from {model_path}"
+
+    assert _pipeline is not None
+    pipe = _pipeline
+
+    try:
+        if device.startswith("cuda"):
+            ctx = torch.autocast(device)
+        else:
+            class _NullCtx:
+                def __enter__(self):
+                    return None
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+            ctx = _NullCtx()
+
+        with ctx:
+            result = pipe(prompt)
+        image = result.images[0]
+        if not hasattr(image, "save"):
+            return "Pipeline did not return an image"
+
+        os.makedirs(save_dir, exist_ok=True)
+        filename = os.path.join(save_dir, f"sd_image_{len(os.listdir(save_dir))+1}.png")
+        image.save(filename)
+        return filename
+    except Exception as exc:  # pragma: no cover - safety net
+        log_error(f"[stable_diffusion_generator] {exc}")
+        return f"Error: {exc}"
+
+
+def get_info() -> dict:
+    """Return module metadata for discovery."""
+    return {
+        "name": MODULE_NAME,
+        "description": "Generate images locally using Stable Diffusion.",
+        "functions": ["generate_image"],
+    }
+
+
+def get_description() -> str:
+    """Return a short description of this module."""
+    return "Local Stable Diffusion image generation utilities."
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,6 +71,7 @@ httpcore==1.0.9
 httptools==0.6.4
 httpx==0.28.1
 huggingface-hub==0.33.4
+diffusers==0.27.2
 humanfriendly==10.0
 idna==3.10
 importlib_metadata==8.7.0

--- a/tests/test_sd_image_generator.py
+++ b/tests/test_sd_image_generator.py
@@ -1,0 +1,55 @@
+import importlib
+import types
+from pathlib import Path
+
+
+def dummy_pipeline_return(prompt: str):
+    class FakeImage:
+        def save(self, path):
+            Path(path).write_text("fake")
+
+    return types.SimpleNamespace(images=[FakeImage()])
+
+
+class DummyPipeline:
+    @classmethod
+    def from_pretrained(cls, path):
+        DummyPipeline.path = path
+        return cls()
+
+    def to(self, device):
+        return self
+
+    def __call__(self, prompt):
+        DummyPipeline.prompt = prompt
+        return dummy_pipeline_return(prompt)
+
+
+def test_generate_image(monkeypatch, tmp_path):
+    diffusers_mod = types.ModuleType('diffusers')
+    diffusers_mod.StableDiffusionPipeline = DummyPipeline
+    monkeypatch.setitem(importlib.sys.modules, 'diffusers', diffusers_mod)
+
+    torch_mod = types.ModuleType('torch')
+
+    class DummyAutocast:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    torch_mod.autocast = lambda *_args, **_kwargs: DummyAutocast()
+    torch_mod.float16 = None
+    monkeypatch.setitem(importlib.sys.modules, 'torch', torch_mod)
+
+    mod = importlib.import_module('modules.stable_diffusion_generator')
+    importlib.reload(mod)
+
+    outdir = tmp_path / 'imgs'
+    result = mod.generate_image('a cat', 'path/to/model', device='cpu', save_dir=str(outdir))
+    assert result.endswith('.png')
+    assert Path(result).exists()
+    assert DummyPipeline.path == 'path/to/model'
+    assert DummyPipeline.prompt == 'a cat'
+


### PR DESCRIPTION
## Summary
- implement `stable_diffusion_generator` module for local image generation using diffusers
- make API modules import requests lazily so tests can patch them
- document the new feature in README
- add unit test for the new Stable Diffusion generator

## Testing
- `ruff check modules/stable_diffusion_generator.py modules/codex_integration.py modules/image_generator.py tests/test_sd_image_generator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882e413aecc8324bf541d777ce51f17