### PR TITLE
Improve window alias parsing

### DIFF
--- a/tests/test_focus_alias.py
+++ b/tests/test_focus_alias.py
@@ -24,3 +24,26 @@ def test_parse_and_execute_focus(monkeypatch):
     result = orch.parse_and_execute('focus spotify')
     assert result == 'focused spotify'
     assert calls['title'] == 'spotify'
+
+
+def test_parse_and_execute_focus_with_window_word(monkeypatch):
+    wt = types.ModuleType('modules.window_tools')
+    args = {}
+
+    def mock_focus(title):
+        args['title'] = title
+        return True, f'focused {title}'
+
+    wt.focus_window = mock_focus
+    wt.__all__ = ['focus_window']
+    monkeypatch.setitem(sys.modules, 'modules.window_tools', wt)
+
+    stub_assistant = types.ModuleType('assistant')
+    stub_assistant.talk_to_llm = lambda t: 'ignored'
+    monkeypatch.setitem(sys.modules, 'assistant', stub_assistant)
+
+    orch = importlib.reload(importlib.import_module('orchestrator'))
+
+    result = orch.parse_and_execute('focus the spotify window')
+    assert result == 'focused spotify'
+    assert args['title'] == 'spotify'

--- a/tests/test_minimize_alias.py
+++ b/tests/test_minimize_alias.py
@@ -24,3 +24,26 @@ def test_parse_and_execute_minimize(monkeypatch):
     result = orch.parse_and_execute('minimize youtube music')
     assert result == 'minimized youtube music'
     assert calls['title'] == 'youtube music'
+
+
+def test_parse_and_execute_minimize_with_window_word(monkeypatch):
+    wt = types.ModuleType('modules.window_tools')
+    args = {}
+
+    def mock_minimize(title):
+        args['title'] = title
+        return True, f'minimized {title}'
+
+    wt.minimize_window = mock_minimize
+    wt.__all__ = ['minimize_window']
+    monkeypatch.setitem(sys.modules, 'modules.window_tools', wt)
+
+    stub_assistant = types.ModuleType('assistant')
+    stub_assistant.talk_to_llm = lambda t: 'ignored'
+    monkeypatch.setitem(sys.modules, 'assistant', stub_assistant)
+
+    orch = importlib.reload(importlib.import_module('orchestrator'))
+
+    result = orch.parse_and_execute('minimize the youtube window')
+    assert result == 'minimized youtube'
+    assert args['title'] == 'youtube'


### PR DESCRIPTION
## Summary
- expand orchestrator regex helpers to strip `window`/`app` from targets
- update focus and minimize alias parsing
- add new tests for window word handling

## Testing
- `ruff check orchestrator.py tests/test_minimize_alias.py tests/test_focus_alias.py`
- `pytest tests/test_minimize_alias.py tests/test_focus_alias.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882ea7a19588324a989fb54b63eb95c