### PR TITLE
Add launcher installer module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 assistant_memory.json
 assistant_state.json
 learned_actions.json
+learned_launchers.json
 
 # VS Code or other editor settings
 .vscode/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Memory viewer/editor:** adjust stored history and `memory_max` from the GUI
 - **Config editor tab:** tweak and save `config.json` without leaving the app
 - **Automatic .exe scanning builds a registry of installed applications**
+- **Download game launchers like Epic Games**
 - **Startup system/device/network scans populate registries and can be refreshed by voice**
 - **Close or terminate apps by window title or process name (e.g. "terminate Rocket League")**
 - **List open windows via the taskbar (e.g. "what windows are open?")**

--- a/cleanup.py
+++ b/cleanup.py
@@ -10,6 +10,7 @@ STATE_FILES = [
     "assistant_memory.json",
     "assistant_state.json",
     "learned_actions.json",
+    "learned_launchers.json",
 ]
 
 PATTERNS = [

--- a/modules/launcher_installer.py
+++ b/modules/launcher_installer.py
@@ -1,0 +1,105 @@
+"""Download and install game launchers from the web."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict
+
+try:
+    import requests
+except Exception as e:  # pragma: no cover - optional dependency
+    requests = None  # type: ignore
+    _IMPORT_ERROR = e
+else:
+    _IMPORT_ERROR = None
+
+import webbrowser
+
+MODULE_NAME = "launcher_installer"
+LAUNCHERS_FILE = "learned_launchers.json"
+EPIC_URL = (
+    "https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/installer/download/"
+    "EpicGamesLauncherInstaller.msi"
+)
+
+__all__ = [
+    "browse",
+    "register_launcher",
+    "install_launcher",
+    "install_epic_launcher",
+    "get_description",
+]
+
+
+def _load_launchers() -> Dict[str, str]:
+    if os.path.isfile(LAUNCHERS_FILE):
+        with open(LAUNCHERS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def _save_launchers(data: Dict[str, str]) -> None:
+    with open(LAUNCHERS_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def browse(url: str) -> str:
+    """Open ``url`` in the user's default browser."""
+    webbrowser.open(url)
+    return f"opened {url}"
+
+
+def register_launcher(name: str, url: str) -> str:
+    """Remember ``url`` for launcher ``name`` in ``LAUNCHERS_FILE``."""
+    data = _load_launchers()
+    data[name] = url
+    _save_launchers(data)
+    return f"registered {name}"
+
+
+def _download_file(url: str, dest: Path, timeout: int = 60) -> Path:
+    if requests is None:
+        raise ImportError(_IMPORT_ERROR)
+    resp = requests.get(url, timeout=timeout)
+    resp.raise_for_status()
+    dest.write_bytes(resp.content)
+    return dest
+
+
+def _install_file(path: Path) -> str:
+    if sys.platform.startswith("win"):
+        try:
+            subprocess.run([str(path)], check=True)
+            return "installed"
+        except Exception as exc:  # pragma: no cover - installation failure
+            return f"install failed: {exc}"
+    return f"downloaded to {path}"  # manual install for non-Windows
+
+
+def install_launcher(name: str, dest_dir: str = ".") -> str:
+    """Download and run the launcher identified by ``name``."""
+    data = _load_launchers()
+    url = data.get(name)
+    if not url:
+        return f"no launcher named {name}"
+    dest = Path(dest_dir) / Path(url).name
+    try:
+        _download_file(url, dest)
+        return _install_file(dest)
+    except Exception as exc:  # pragma: no cover - network failure
+        return f"error: {exc}"
+
+
+def install_epic_launcher(dest_dir: str = ".") -> str:
+    """Download and install the Epic Games Launcher."""
+    register_launcher("epic", EPIC_URL)
+    return install_launcher("epic", dest_dir)
+
+
+def get_description() -> str:
+    return "Downloads and installs game launchers like Epic Games."
+

--- a/tests/test_launcher_installer.py
+++ b/tests/test_launcher_installer.py
@@ -1,0 +1,34 @@
+import importlib
+import json
+from pathlib import Path
+import types
+
+
+def _setup_requests(monkeypatch):
+    class DummyResp:
+        content = b'data'
+
+        def raise_for_status(self):
+            pass
+
+    mod = types.SimpleNamespace(get=lambda url, timeout=60: DummyResp())
+    monkeypatch.setitem(importlib.import_module('modules.launcher_installer').__dict__, 'requests', mod)
+
+
+def test_register_launcher(tmp_path, monkeypatch):
+    li = importlib.import_module('modules.launcher_installer')
+    monkeypatch.chdir(tmp_path)
+    li.register_launcher('foo', 'https://example.com/foo.exe')
+    data = json.loads(Path('learned_launchers.json').read_text())
+    assert data['foo'] == 'https://example.com/foo.exe'
+
+
+def test_install_epic_launcher(tmp_path, monkeypatch):
+    li = importlib.import_module('modules.launcher_installer')
+    monkeypatch.chdir(tmp_path)
+    _setup_requests(monkeypatch)
+    monkeypatch.setattr(li, '_install_file', lambda path: 'installed')
+    result = li.install_epic_launcher()
+    assert result == 'installed'
+    assert Path('EpicGamesLauncherInstaller.msi').exists()
+


### PR DESCRIPTION
## Summary
- add a new `launcher_installer` module for downloading game launchers
- store custom launcher URLs in `learned_launchers.json`
- register the Epic Games launcher and expose helpers to install it
- ignore new state file in `.gitignore` and clean it via `cleanup.py`
- document the capability in README
- add unit tests for registering and installing launchers

## Testing
- `ruff check modules/launcher_installer.py tests/test_launcher_installer.py cleanup.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f307a39c8324bdf62d8aa3c2ed86