### PR TITLE
Add GUI settings tab for remote LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Fast onboarding: all config, shortcuts, and memory are editable text**
 - **Memory viewer/editor:** adjust stored history and `memory_max` from the GUI
 - **Config editor tab:** tweak and save `config.json` without leaving the app
+- **Settings tab:** quickly switch between local and remote LLM servers
 - **Automatic .exe scanning builds a registry of installed applications**
 - **Download game launchers like Epic Games**
 - **Startup system/device/network scans populate registries and can be refreshed by voice**
@@ -188,7 +189,8 @@ your local network:
    ollama serve
    ```
    (Assuming the host IP is `192.168.1.50`.)
-2. On the assistant PC, edit `config.json` and set:
+2. On the assistant PC, open the **Settings** tab (or edit `config.json`) and
+   enable *Use remote Ollama server* with the URL:
    ```json
    "llm_url": "http://192.168.1.50:11434/v1/chat/completions"
    ```

--- a/config_validator.py
+++ b/config_validator.py
@@ -20,6 +20,7 @@ CONFIG_SCHEMA = {
                 {"type": "string", "enum": ["auto"]},
             ]
         },
+        "llm_url": {"type": "string"},
         "llm_backend": {"type": "string"},
         "llm_model": {"type": "string"},
         "vosk_model_path": {"type": "string"},

--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -94,6 +94,7 @@ hotkey_tab = ttk.Frame(notebook)
 module_tab = ttk.Frame(notebook)
 image_tab = ttk.Frame(notebook)
 web_tab = ttk.Frame(notebook)
+settings_tab = ttk.Frame(notebook)
 notebook.add(main_tab, text="Assistant")
 notebook.add(speech_tab, text="Speech Learning")
 notebook.add(config_tab, text="Config Editor")
@@ -101,6 +102,7 @@ notebook.add(hotkey_tab, text="Hotkeys")
 notebook.add(module_tab, text="Module Generator")
 notebook.add(image_tab, text="Image Generator")
 notebook.add(web_tab, text="Web Activity")
+notebook.add(settings_tab, text="Settings")
 
 # ---------- Config Editor Tab ----------
 config_text = tk.Text(config_tab, wrap=tk.WORD)
@@ -764,6 +766,40 @@ def run_web_search(_event=None) -> None:
 web_entry.bind("<Return>", run_web_search)
 ttk.Button(web_tab, text="Go", command=run_web_search).pack(pady=(0, 10))
 set_webview_callback(_load_url)
+
+# ---------- Settings Tab ----------
+use_remote_var = tk.BooleanVar(value=bool(config.get("llm_url")))
+url_var = tk.StringVar(value=config.get("llm_url", "http://localhost:11434/v1/chat/completions"))
+
+def _toggle_remote() -> None:
+    state = tk.NORMAL if use_remote_var.get() else tk.DISABLED
+    url_entry.config(state=state)
+
+ttk.Checkbutton(
+    settings_tab,
+    text="Use remote Ollama server",
+    variable=use_remote_var,
+    command=_toggle_remote,
+).pack(anchor="w", padx=10, pady=(10, 5))
+
+ttk.Label(settings_tab, text="LLM URL:").pack(anchor="w", padx=10)
+url_entry = ttk.Entry(settings_tab, textvariable=url_var, width=50)
+url_entry.pack(fill="x", padx=10)
+
+def save_settings() -> None:
+    cfg = config_loader.config
+    if use_remote_var.get():
+        cfg["llm_url"] = url_var.get().strip()
+    else:
+        cfg.pop("llm_url", None)
+    with open("config.json", "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+    config_loader.config = cfg
+    output.insert(tk.END, "[SYSTEM] Settings saved.\n")
+    reload_config()
+
+ttk.Button(settings_tab, text="Save Settings", command=save_settings).pack(pady=10)
+_toggle_remote()
 
 # ---------- Speech Learning Tab ----------
 speech_label = ttk.Label(

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -48,3 +48,11 @@ def test_generate_response_missing_fields(monkeypatch):
     llm_interface.config["llm_backend"] = "localai"
     result = llm_interface.generate_response("hi", history=[])
     assert result.startswith("[LLM Error]")
+
+
+def test_get_url_override():
+    llm_interface.config["llm_url"] = "http://remote:11434/v1/chat/completions"
+    assert llm_interface._get_url() == "http://remote:11434/v1/chat/completions"
+    llm_interface.config.pop("llm_url", None)
+    llm_interface.config["llm_backend"] = "localai"
+    assert "localhost" in llm_interface._get_url()


### PR DESCRIPTION
## Summary
- add Settings tab in GUI to toggle remote Ollama server
- validate optional `llm_url` in config schema
- test URL override logic in `llm_interface`
- document the new tab and update remote server instructions

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f6e4b0d48324a573e2919014cb6f