### PR TITLE
Add speech volume controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Emulation mode:** set `emulate_actions` to true to practice commands safely
 - **Crash prevention:** unexpected errors are logged and the assistant says "Crash prevented" before resuming. Module calls are wrapped so exceptions never terminate the app.
 
-Adjust voice playback on the fly with phrases like "set speech speed to 1.2", "increase volume", or "use jenny voice." The GUI sliders and menu mirror these settings.
+Adjust voice playback on the fly with phrases like "set speech speed to 1.2", "increase volume", or "use jenny voice." The GUI sliders and menu mirror these settings. In CLI mode you can also run `set speech volume 80` to change the TTS volume.
 
 ---
 

--- a/assistant.py
+++ b/assistant.py
@@ -332,6 +332,25 @@ def process_input(user_input, output_widget):
                 return
 
             # === Volume commands ===
+            m = re.search(r"set (?:speech|tts) volume(?: to)? ([0-9]*\.?[0-9]+)", text.lower())
+            if m:
+                val = float(m.group(1))
+                from modules import tts_integration
+
+                if val > 1:
+                    val = val / 100.0
+                ok = tts_integration.set_volume(val)
+                msg = (
+                    f"Volume set to {val}"
+                    if ok is True
+                    else "Invalid volume. Use 0.0 to 1.0"
+                )
+                output_widget.insert("end", f"Assistant: {msg}\n")
+                output_widget.see("end")
+                speak(msg)
+                last_ai_response = msg
+                return
+
             m = re.search(r"set (?:system )?volume(?: to)? ([0-9]*\.?[0-9]+)", text.lower())
             if m:
                 val = float(m.group(1))
@@ -371,7 +390,7 @@ def process_input(user_input, output_widget):
                 speak(msg)
                 last_ai_response = msg
                 return
-            if "increase volume" in text.lower():
+            if "increase speech volume" in text.lower() or "speech volume up" in text.lower() or "increase volume" in text.lower():
                 from modules import tts_integration
 
                 val = min(tts_integration.config.get("tts_volume", 0.8) + 0.1, 1.0)
@@ -382,7 +401,13 @@ def process_input(user_input, output_widget):
                 speak(msg)
                 last_ai_response = msg
                 return
-            if "decrease volume" in text.lower() or "lower volume" in text.lower():
+            if (
+                "decrease speech volume" in text.lower()
+                or "lower speech volume" in text.lower()
+                or "speech volume down" in text.lower()
+                or "decrease volume" in text.lower()
+                or "lower volume" in text.lower()
+            ):
                 from modules import tts_integration
 
                 val = max(tts_integration.config.get("tts_volume", 0.8) - 0.1, 0.0)

--- a/cli_assistant.py
+++ b/cli_assistant.py
@@ -43,15 +43,40 @@ def process_command(user_input: str):
 
         return system_volume.set_volume(value)
 
+    if cmd.startswith("set speech volume "):
+        try:
+            value = float(cmd.split("set speech volume ", 1)[1])
+        except ValueError:
+            return "[Error] Invalid volume"
+        from modules import tts_integration
+        if value > 1:
+            value = value / 100.0
+        result = tts_integration.set_volume(value)
+        return "Speech volume set" if result is True else result
+
     if cmd in {"volume up", "increase volume"}:
         from modules import media_controls
 
         return media_controls.volume_up()
 
+    if cmd in {"speech volume up", "increase speech volume"}:
+        from modules import tts_integration
+
+        val = min(tts_integration.config.get("tts_volume", 0.8) + 0.1, 1.0)
+        tts_integration.set_volume(val)
+        return f"Speech volume set to {val}"
+
     if cmd in {"volume down", "decrease volume"}:
         from modules import media_controls
 
         return media_controls.volume_down()
+
+    if cmd in {"speech volume down", "decrease speech volume"}:
+        from modules import tts_integration
+
+        val = max(tts_integration.config.get("tts_volume", 0.8) - 0.1, 0.0)
+        tts_integration.set_volume(val)
+        return f"Speech volume set to {val}"
 
     if cmd in {"start recording", "stop recording", "toggle recording"}:
         from modules import gamebar_capture

--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -414,9 +414,17 @@ def reload_config():
     if errors:
         output.insert(tk.END, "[CONFIG VALIDATION ERROR]\n" + "\n".join(errors) + "\n")
         speak("Reload failed due to config error.")
-    else:
-        output.insert(tk.END, "[SYSTEM] Config reloaded and validated!\n")
-        speak("Configuration has been reloaded.")
+        return
+
+    output.insert(tk.END, "[SYSTEM] Config reloaded and validated!\n")
+    speak("Configuration has been reloaded.")
+
+    # Mirror updated values in the UI controls
+    volume_scale.set(config.get("tts_volume", 0.8))
+    speed_scale.set(config.get("tts_speed", 1.0))
+    tts_module.config.update(config)
+    current_voice = config.get("tts_voice") or voice_var.get()
+    voice_var.set(current_voice)
 
 # ========== BUTTON HANDLER (UI ONLY) ==========
 buttons_frame = ttk.Frame(entry_frame)

--- a/modules/web_activity.py
+++ b/modules/web_activity.py
@@ -42,7 +42,6 @@ def load_url(url: str, html_view: Optional[object] = None) -> None:
         Optional :class:`tkinterweb.HtmlFrame` instance. If ``None`` or loading
         fails, the URL is opened in the user's default browser.
     """
-    global _HISTORY
     if html_view and hasattr(html_view, "load_website"):
         try:
             html_view.load_website(url)

--- a/tests/test_cli_volume.py
+++ b/tests/test_cli_volume.py
@@ -34,3 +34,32 @@ def test_cli_volume_up(monkeypatch):
     out = process_command('volume up')
     assert calls == ['up']
     assert out == 'ok'
+
+
+def test_cli_set_speech_volume(monkeypatch):
+    tts = importlib.import_module('modules.tts_integration')
+    calls = []
+    monkeypatch.setattr(tts, 'set_volume', lambda v: calls.append(v) or True)
+    out = process_command('set speech volume 70')
+    assert calls == [0.7]
+    assert out == 'Speech volume set'
+
+
+def test_cli_speech_volume_up(monkeypatch):
+    tts = importlib.import_module('modules.tts_integration')
+    monkeypatch.setattr(tts, 'config', {'tts_volume': 0.5})
+    calls = []
+    monkeypatch.setattr(tts, 'set_volume', lambda v: calls.append(v) or True)
+    out = process_command('speech volume up')
+    assert calls == [0.6]
+    assert out == 'Speech volume set to 0.6'
+
+
+def test_cli_speech_volume_down(monkeypatch):
+    tts = importlib.import_module('modules.tts_integration')
+    monkeypatch.setattr(tts, 'config', {'tts_volume': 0.5})
+    calls = []
+    monkeypatch.setattr(tts, 'set_volume', lambda v: calls.append(v) or True)
+    out = process_command('speech volume down')
+    assert calls == [0.4]
+    assert out == 'Speech volume set to 0.4'

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -109,3 +109,26 @@ def test_process_input_increase_system_volume(monkeypatch):
     assistant.set_listening(True)
     assistant.process_input('increase system volume', DummyWidget())
     assert calls == ['up']
+
+
+def test_process_input_set_speech_volume(monkeypatch):
+    assistant, _ = import_assistant(monkeypatch)
+    monkeypatch.setattr(assistant, 'speak', lambda *a, **kw: None)
+    tts = importlib.import_module('modules.tts_integration')
+    calls = []
+    monkeypatch.setattr(tts, 'set_volume', lambda v: calls.append(v) or True)
+    assistant.set_listening(True)
+    assistant.process_input('set speech volume to 70', DummyWidget())
+    assert calls == [0.7]
+
+
+def test_process_input_increase_speech_volume(monkeypatch):
+    assistant, _ = import_assistant(monkeypatch)
+    monkeypatch.setattr(assistant, 'speak', lambda *a, **kw: None)
+    tts = importlib.import_module('modules.tts_integration')
+    monkeypatch.setattr(tts, 'config', {'tts_volume': 0.5})
+    calls = []
+    monkeypatch.setattr(tts, 'set_volume', lambda v: calls.append(v) or True)
+    assistant.set_listening(True)
+    assistant.process_input('increase speech volume', DummyWidget())
+    assert calls == [0.6]


### PR DESCRIPTION
## Summary
- allow TTS volume to be controlled from CLI
- recognize voice commands like "set speech volume" and "increase speech volume"
- mention CLI speech volume command in the docs
- test new CLI and voice volume functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882fcca1748832492f7c31a3fb2b6df