### PR TITLE
Save generated images within project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ assistant_memory.json
 assistant_state.json
 learned_actions.json
 learned_launchers.json
+generated_images/
 
 # VS Code or other editor settings
 .vscode/

--- a/modules/image_generator.py
+++ b/modules/image_generator.py
@@ -10,6 +10,7 @@ import importlib
 
 from error_logger import log_error
 from modules.api_keys import get_api_key
+from modules.utils import project_path
 
 MODULE_NAME = "image_generator"
 
@@ -37,7 +38,8 @@ def generate_image(
     size:
         Image resolution string (for providers that support it), e.g. ``"512x512"``.
     save_dir:
-        Folder to store generated images.
+        Folder within the project directory to store generated images. If an
+        absolute path is provided it will be used as-is.
 
     Returns
     -------
@@ -77,6 +79,8 @@ def generate_image(
         if not b64:
             return "No image data returned"
         image_bytes = base64.b64decode(b64)
+        if not os.path.isabs(save_dir):
+            save_dir = project_path(save_dir)
         os.makedirs(save_dir, exist_ok=True)
         filename = os.path.join(save_dir, f"image_{len(os.listdir(save_dir)) + 1}.png")
         with open(filename, "wb") as f:

--- a/modules/stable_diffusion_generator.py
+++ b/modules/stable_diffusion_generator.py
@@ -25,6 +25,7 @@ else:
 
 
 from error_logger import log_error
+from modules.utils import project_path
 
 MODULE_NAME = "stable_diffusion_generator"
 
@@ -82,7 +83,8 @@ def generate_image(
         PyTorch device string (``"cpu"`` or ``"cuda"``). ``None`` selects the
         best device via :func:`modules.gpu.get_device`.
     save_dir:
-        Directory to store generated images.
+        Directory within the project where images will be saved. Relative paths
+        are resolved against the project root.
 
     Returns
     -------
@@ -110,6 +112,8 @@ def generate_image(
         if not hasattr(image, "save"):
             return "Pipeline did not return an image"
 
+        if not os.path.isabs(save_dir):
+            save_dir = project_path(save_dir)
         os.makedirs(save_dir, exist_ok=True)
         filename = os.path.join(save_dir, f"sd_image_{len(os.listdir(save_dir))+1}.png")
         image.save(filename)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -3,8 +3,9 @@
 import os
 import sys
 import re
+from pathlib import Path
 
-__all__ = ["resource_path", "chunk_text", "clean_for_tts"]
+__all__ = ["resource_path", "project_path", "chunk_text", "clean_for_tts"]
 
 def resource_path(relative_path: str) -> str:
     """Return absolute path for ``relative_path`` inside packaged app."""
@@ -13,6 +14,17 @@ def resource_path(relative_path: str) -> str:
     except AttributeError:
         base_path = os.path.abspath(".")
     return os.path.join(base_path, relative_path)
+
+
+def project_path(*parts: str) -> str:
+    """Return an absolute path within the project directory.
+
+    This resolves paths relative to the repository root so modules can
+    reliably access bundled data regardless of the current working
+    directory.
+    """
+    root = Path(__file__).resolve().parents[1]
+    return str(root.joinpath(*parts))
 
 def chunk_text(text: str, max_length: int = 220) -> list[str]:
     """Split ``text`` into sentence chunks no longer than ``max_length``."""
@@ -41,7 +53,12 @@ def get_info():
         "name": "utils",
         "description": "General utility functions used across the assistant.",
         # List the functions actually provided by this module
-        "functions": ["resource_path", "chunk_text", "clean_for_tts"]
+        "functions": [
+            "resource_path",
+            "project_path",
+            "chunk_text",
+            "clean_for_tts",
+        ]
     }
 
 

--- a/tests/test_image_generator.py
+++ b/tests/test_image_generator.py
@@ -2,6 +2,7 @@ import base64
 import importlib
 import os
 import types
+from pathlib import Path
 
 import pytest
 
@@ -37,4 +38,17 @@ def test_generate_image(monkeypatch, tmp_path):
     assert result.endswith(".png")
     assert os.path.exists(result)
     assert mock_post.last_payload["model"] == "dall-e-3"
+
+
+def test_default_save_dir(monkeypatch):
+    os.environ["OPENAI_API_KEY"] = "test"
+    ig = importlib.import_module("modules.image_generator")
+    project_root = Path(__file__).resolve().parents[1]
+
+    monkeypatch.chdir(project_root / "examples")
+    result = ig.generate_image("a tree")
+    path = Path(result)
+    assert path.parent == project_root / "generated_images"
+    assert path.exists()
+    path.unlink()
 


### PR DESCRIPTION
## Summary
- ensure project-relative paths via `project_path`
- default image generators save under `generated_images`
- ignore generated images in git
- test new default save directory

## Testing
- `pytest tests/test_image_generator.py::test_generate_image -q`
- `pytest tests/test_image_generator.py::test_default_save_dir -q`
- `pytest tests/test_sd_image_generator.py::test_generate_image -q`
- `pytest tests/test_image_generator.py tests/test_sd_image_generator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883156e75e483248e4560f13fd8b178