### PR TITLE
Add LLM model selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Fast onboarding: all config, shortcuts, and memory are editable text**
 - **Memory viewer/editor:** adjust stored history and `memory_max` from the GUI
 - **Config editor tab:** tweak and save `config.json` without leaving the app
-- **Settings tab:** quickly switch between local and remote LLM servers
+- **Settings tab:** quickly switch between local and remote LLM servers and choose your preferred LLM model
 - **Automatic .exe scanning builds a registry of installed applications**
 - **Download game launchers like Epic Games**
 - **Startup system/device/network scans populate registries and can be refreshed by voice**

--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -917,6 +917,7 @@ url_var = tk.StringVar(value=config.get("llm_url", "http://localhost:11434/v1/ch
 def _toggle_remote() -> None:
     state = tk.NORMAL if use_remote_var.get() else tk.DISABLED
     url_entry.config(state=state)
+    model_menu.config(state=tk.DISABLED if use_remote_var.get() else tk.NORMAL)
 
 ttk.Checkbutton(
     settings_tab,
@@ -929,12 +930,22 @@ ttk.Label(settings_tab, text="LLM URL:").pack(anchor="w", padx=10)
 url_entry = ttk.Entry(settings_tab, textvariable=url_var, width=50)
 url_entry.pack(fill="x", padx=10)
 
+# LLM Model selector
+ttk.Label(settings_tab, text="LLM Model:").pack(anchor="w", padx=10, pady=(10, 0))
+models = llm_interface.list_models()
+current_model = config.get("llm_model") or (models[0] if models else "")
+model_var = tk.StringVar(value=current_model)
+model_menu = ttk.OptionMenu(settings_tab, model_var, current_model, *models)
+model_menu.pack(anchor="w", padx=10)
+
 def save_settings() -> None:
     cfg = config_loader.config
     if use_remote_var.get():
         cfg["llm_url"] = url_var.get().strip()
     else:
         cfg.pop("llm_url", None)
+    if model_var.get():
+        cfg["llm_model"] = model_var.get().strip()
     with open("config.json", "w", encoding="utf-8") as f:
         json.dump(cfg, f, indent=2)
     config_loader.config = cfg

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -56,3 +56,24 @@ def test_get_url_override():
     llm_interface.config.pop("llm_url", None)
     llm_interface.config["llm_backend"] = "localai"
     assert "localhost" in llm_interface._get_url()
+
+
+def test_list_models_localai(tmp_path, monkeypatch):
+    models_dir = tmp_path / "LocalAI" / "models"
+    models_dir.mkdir(parents=True)
+    (models_dir / "m1").mkdir()
+    (models_dir / "m2.gguf").touch()
+    monkeypatch.chdir(tmp_path)
+    llm_interface.config["llm_backend"] = "localai"
+    assert sorted(llm_interface.list_models()) == ["m1", "m2"]
+
+
+def test_list_models_ollama(monkeypatch):
+    output = "modelA 7B\nmodelB 13B"
+    monkeypatch.setattr(
+        llm_interface.subprocess,
+        "check_output",
+        lambda cmd, text=True: output,
+    )
+    llm_interface.config["llm_backend"] = "ollama"
+    assert llm_interface.list_models() == ["modelA", "modelB"]


### PR DESCRIPTION
## Summary
- list available models for each backend via `llm_interface.list_models`
- expose a model dropdown on the GUI Settings tab
- persist selected model to `config.json`
- document the new GUI feature in README
- cover the `list_models` logic with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688315db0c7c8324a79ec1d49e875c48