### PR TITLE
Add selectable TTS models

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,12 @@ Offline use requires a few additional assets:
 1. **Vosk speech model** – grab `vosk-model-small-en-us-0.15` from
    <https://alphacephei.com/vosk/models> and extract it to the path specified by
    `vosk_model_path` in `config.json`.
-2. **Coqui TTS voice** – run
-   `tts --model tts_models/en/jenny/jenny --download` or download another voice
-   from the [Coqui TTS](https://github.com/coqui-ai/TTS) project. Update
-   `tts_model` in `config.json` with the chosen voice.
+2. **Coqui TTS voice** – run a command like
+   `tts --model tts_models/en/jenny/jenny --download` or download another
+   voice from the [Coqui TTS](https://github.com/coqui-ai/TTS) project.
+   Popular models include `tts_models/en/vctk/vits` and
+   `tts_models/en/ljspeech/tacotron2-DDC`. Update `tts_model` in
+   `config.json` with the chosen voice.
 3. **LLM backends** – clone LocalAI, text-generation-webui, and Ollama by running
    `python install_llm_backends.py --all` (or the `.bat` file on Windows).
    Follow each backend’s README to place your LLM weights in its `models/`

--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -424,6 +424,8 @@ def reload_config():
     volume_scale.set(config.get("tts_volume", 0.8))
     speed_scale.set(config.get("tts_speed", 1.0))
     tts_module.config.update(config)
+    current_model = config.get("tts_model") or model_var.get()
+    model_var.set(current_model)
     current_voice = config.get("tts_voice") or voice_var.get()
     voice_var.set(current_voice)
 
@@ -473,6 +475,21 @@ volume_scale = tk.Scale(
 )
 volume_scale.set(config.get("tts_volume", 0.8))
 volume_scale.pack(side=tk.LEFT, padx=(0, 10))
+
+# ========== TTS MODEL MENU ==========
+models = tts_module.list_models()
+model_var = tk.StringVar()
+current_model = config.get("tts_model") or (models[0] if models else "")
+model_var.set(current_model)
+model_menu = ttk.OptionMenu(
+    tts_frame,
+    model_var,
+    current_model,
+    *models,
+    command=lambda m: tts_module.set_model(m),
+)
+model_menu.configure(text="TTS Model")
+model_menu.pack(side=tk.LEFT, padx=(0, 10))
 
 # ========== TTS VOICE MENU ==========
 voices = tts_module.list_voices()

--- a/tests/test_tts_controls.py
+++ b/tests/test_tts_controls.py
@@ -65,3 +65,15 @@ def test_set_speed(monkeypatch, tmp_path):
     assert tts.config["tts_speed"] == 1.2
 
     assert tts.set_speed(2.5) is False
+
+
+def test_set_model_and_list(monkeypatch, tmp_path):
+    tts, cfg_file = setup_tts(monkeypatch, tmp_path)
+
+    models = tts.list_models()
+    assert isinstance(models, list)
+
+    assert tts.set_model("new_model") is True
+    saved = json.loads(cfg_file.read_text())
+    assert saved["tts_model"] == "new_model"
+    assert tts.config["tts_model"] == "new_model"


### PR DESCRIPTION
## Summary
- expose a curated list of TTS models in `tts_integration`
- support changing the active model at runtime and updating config
- surface a TTS model dropdown in the GUI
- document example models in README
- test setting TTS model via `set_model`

## Testing
- `ruff check gui_assistant.py modules/tts_integration.py tests/test_tts_controls.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68831600c1088324a2cb1885098747e2