### PR TITLE
Add TTS model selector window

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Fast onboarding: all config, shortcuts, and memory are editable text**
 - **Memory viewer/editor:** adjust stored history and `memory_max` from the GUI
 - **Config editor tab:** tweak and save `config.json` without leaving the app
-- **Settings tab:** quickly switch between local and remote LLM servers and choose your preferred LLM model
+- **Settings tab:** quickly switch between local and remote LLM servers, choose your preferred LLM model, and select a TTS model
 - **Automatic .exe scanning builds a registry of installed applications**
 - **Download game launchers like Epic Games**
 - **Startup system/device/network scans populate registries and can be refreshed by voice**

--- a/config_gui.py
+++ b/config_gui.py
@@ -3,7 +3,13 @@
 import json
 import tkinter as tk
 from tkinter import messagebox
+try:
+    from tkinter import ttk
+except Exception:  # pragma: no cover - missing ttk in tests
+    ttk = None  # type: ignore
 import memory_manager as mm
+from error_logger import log_error
+from modules import tts_integration
 
 CONFIG_FILE = "config.json"
 
@@ -53,6 +59,40 @@ def open_memory_window():
         messagebox.showinfo("Saved", "Memory updated")
 
     tk.Button(win, text="Save", command=save).pack(pady=5)
+    return win
+
+
+def open_tts_model_window():
+    """Display available TTS models and allow switching."""
+    win = tk.Toplevel()
+    win.title("TTS Model Selector")
+
+    try:
+        models = tts_integration.list_models()
+    except Exception as exc:  # pragma: no cover - unexpected import errors
+        log_error(f"[TTS] list_models failed: {exc}")
+        models = []
+
+    tk.Label(win, text="TTS Model:").pack(pady=(5, 0))
+    current = tts_integration.config.get("tts_model")
+    if current not in models and models:
+        current = models[0]
+    var = tk.StringVar(value=current)
+    try:
+        menu = ttk.OptionMenu(win, var, var.get(), *models)
+    except Exception:  # pragma: no cover - ttk may be missing in tests
+        menu = tk.OptionMenu(win, var, *models)
+    menu.pack(padx=10, pady=5)
+
+    def save() -> None:
+        try:
+            tts_integration.set_model(var.get())
+            messagebox.showinfo("Saved", "TTS model updated")
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            log_error(f"[TTS] set_model failed: {exc}")
+        win.destroy()
+
+    tk.Button(win, text="Save", command=save).pack(pady=(0, 10))
     return win
 
 def open_config_window():

--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -39,7 +39,7 @@ except Exception:
     WATCHDOG_AVAILABLE = False
 from config_loader import ConfigLoader
 from config_validator import validate_config
-from config_gui import open_memory_window
+from config_gui import open_memory_window, open_tts_model_window
 from assistant import set_screen_viewer_callback
 from assistant import (
     process_input,
@@ -954,6 +954,12 @@ current_model = config.get("llm_model") or (models[0] if models else "")
 model_var = tk.StringVar(value=current_model)
 model_menu = ttk.OptionMenu(settings_tab, model_var, current_model, *models)
 model_menu.pack(anchor="w", padx=10)
+
+ttk.Button(
+    settings_tab,
+    text="Choose TTS Model",
+    command=open_tts_model_window,
+).pack(anchor="w", padx=10, pady=(5, 0))
 
 def save_settings() -> None:
     cfg = config_loader.config

--- a/tests/test_tts_model_window.py
+++ b/tests/test_tts_model_window.py
@@ -1,0 +1,43 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+def test_open_tts_model_window(monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    # stub tkinter
+    tk_stub = types.ModuleType("tkinter")
+    mb_stub = types.ModuleType("messagebox")
+    mb_stub.showinfo = lambda *a, **k: None
+    class DummyWidget:
+        def pack(self, *a, **k):
+            pass
+        def grid(self, *a, **k):
+            pass
+        def title(self, *a, **k):
+            pass
+    class DummyOption(DummyWidget):
+        pass
+    tk_stub.Toplevel = lambda: DummyWidget()
+    tk_stub.Label = lambda *a, **k: DummyWidget()
+    tk_stub.Button = lambda *a, **k: DummyWidget()
+    tk_stub.OptionMenu = lambda *a, **k: DummyOption()
+    tk_stub.StringVar = lambda value="": types.SimpleNamespace(get=lambda: value, set=lambda v: None)
+    tk_stub.END = "end"
+    tk_stub.messagebox = mb_stub
+    tk_stub.ttk = types.SimpleNamespace(OptionMenu=lambda *a, **k: DummyOption())
+    monkeypatch.setitem(sys.modules, "tkinter", tk_stub)
+    monkeypatch.setitem(sys.modules, "tkinter.messagebox", mb_stub)
+
+    # stub tts_integration
+    tts_stub = types.ModuleType("tts_integration")
+    tts_stub.list_models = lambda: ["m1", "m2"]
+    tts_stub.set_model = lambda m: None
+    tts_stub.config = {"tts_model": "m1"}
+    monkeypatch.setitem(sys.modules, "modules.tts_integration", tts_stub)
+
+    cg = importlib.import_module("config_gui")
+    importlib.reload(cg)
+    win = cg.open_tts_model_window()
+    assert win is not None


### PR DESCRIPTION
## Summary
- let Settings tab open a TTS model selection window
- provide GUI helper `open_tts_model_window` in `config_gui`
- test that the TTS model window opens with stubbed Tkinter
- document the new capability in the README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883182d3988832484dc1b6adaae3cf3