### PR TITLE
Fix TkinterWeb debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Adjust voice playback on the fly with phrases like "set speech speed to 1.2", "i
 - [Vosk](https://alphacephei.com/vosk/) speech model (see config for path)
 - `sounddevice` (audio playback and microphone input)
 - `watchdog` (for live config reload, highly recommended)
-- `tkinterweb` for the built-in browser tab (optional)
+- `tkinterweb` for the built-in browser tab (optional; use `messages_enabled=False` to hide debug messages)
 - [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) for vision tools
   (on Windows set `TESSERACT_CMD` if not installed in the default location)
 - `pygetwindow` (or `wmctrl` on Linux) for listing open windows and focusing

--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -881,7 +881,8 @@ web_entry = ttk.Entry(web_tab, textvariable=web_search_var)
 web_entry.pack(fill="x", padx=10)
 
 if HtmlFrame:
-    web_view = HtmlFrame(web_tab)
+    # Disable TkinterWeb debug messages for cleaner console output
+    web_view = HtmlFrame(web_tab, messages_enabled=False)
     web_view.pack(fill="both", expand=True, padx=10, pady=10)
 else:
     # Fallback text widget if tkinterweb isn't installed

--- a/tests/test_tkinterweb_messages.py
+++ b/tests/test_tkinterweb_messages.py
@@ -1,0 +1,8 @@
+import re
+from pathlib import Path
+
+
+def test_htmlframe_messages_disabled():
+    text = Path("gui_assistant.py").read_text()
+    pattern = re.compile(r"HtmlFrame\(.*messages_enabled=False")
+    assert pattern.search(text), "HtmlFrame should disable debug messages"


### PR DESCRIPTION
## Summary
- disable TkinterWeb messages in `gui_assistant`
- document how to suppress TkinterWeb debug output
- add regression test for HtmlFrame flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688319558b0483248c5449ef385e3ea3