### PR TITLE
Handle TTS load failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Automatic multi-command parsing:** say "play music and open Rocket League" to run tasks one after another
 - **Tutorial mode:** ask "what does `function_name` do?" to hear documentation
 - **Emulation mode:** set `emulate_actions` to true to practice commands safely
-- **Crash prevention:** unexpected errors are logged and the assistant says "Crash prevented" before resuming. Module calls are wrapped so exceptions never terminate the app.
+- **Crash prevention:** unexpected errors are logged and the assistant says "Crash prevented" before resuming. Module calls are wrapped so exceptions never terminate the app. TTS model load failures are now caught.
 
 Adjust voice playback on the fly with phrases like "set speech speed to 1.2", "increase volume", or "use jenny voice." The GUI sliders and menu mirror these settings. In CLI mode you can also run `set speech volume 80` to change the TTS volume.
 

--- a/modules/tts_integration.py
+++ b/modules/tts_integration.py
@@ -97,7 +97,11 @@ def speak(text, voice=None, volume=None, speed=None, async_play=True, on_complet
     # Enforce a single unified voice profile from config
     voice = config.get("tts_voice") or voice
     volume = volume if volume is not None else config.get("tts_volume", 0.8)
-    model = get_tts_model()
+    try:
+        model = get_tts_model()
+    except Exception as e:
+        log_error(f"[{MODULE_NAME}] load error: {e}")
+        return f"[TTS] load error: {e}"
     if speed is None:
         speed = config.get("tts_speed", 1.0)
     chunks = chunk_text(text)

--- a/tests/test_tts_load_error.py
+++ b/tests/test_tts_load_error.py
@@ -1,0 +1,29 @@
+import importlib
+import sys
+import types
+
+
+def test_tts_load_error(monkeypatch):
+    """Model loading errors should be caught and returned as a message."""
+    np_stub = types.ModuleType("numpy")
+    np_stub.array = lambda x: x
+    sd_stub = types.ModuleType("sounddevice")
+    sd_stub.play = lambda *a, **kw: None
+    sd_stub.wait = lambda: None
+    monkeypatch.setitem(sys.modules, "numpy", np_stub)
+    monkeypatch.setitem(sys.modules, "sounddevice", sd_stub)
+
+    api_stub = types.ModuleType("TTS.api")
+    def fail(*a, **kw):
+        raise RuntimeError("load fail")
+    api_stub.TTS = fail
+    tts_stub = types.ModuleType("TTS")
+    tts_stub.api = api_stub
+    monkeypatch.setitem(sys.modules, "TTS", tts_stub)
+    monkeypatch.setitem(sys.modules, "TTS.api", api_stub)
+
+    tts = importlib.import_module("modules.tts_integration")
+    importlib.reload(tts)
+
+    result = tts.speak("hello", async_play=False)
+    assert result.startswith("[TTS] load error:")


### PR DESCRIPTION
## Summary
- guard Coqui model initialization in `speak`
- test Coqui init failure handling
- document TTS load error handling in README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68831dbd544c83248cd8b36a8cb0914d