### PR TITLE
Remove unused fallback constant

### DIFF
--- a/llm_interface.py
+++ b/llm_interface.py
@@ -15,9 +15,6 @@ SYSTEM_PROMPT = (
     "You use local memory to recall past events and can control the system through modules."
 )
 
-# Friendly reply used if the LLM response is malformed
-DEFAULT_FALLBACK = "I'm doing well, thanks for asking!"
-
 
 def _module_prompt() -> str:
     """Return a short description of available modules for the system prompt."""

--- a/tests/test_assistant_utils.py
+++ b/tests/test_assistant_utils.py
@@ -7,7 +7,6 @@ def import_assistant(monkeypatch):
     # Minimal stubs for required modules
     li = types.ModuleType('llm_interface')
     li.generate_response = lambda *a, **kw: 'ok'
-    li.DEFAULT_FALLBACK = "fallback"
     monkeypatch.setitem(sys.modules, 'llm_interface', li)
     monkeypatch.setitem(sys.modules, 'keyboard', types.ModuleType('keyboard'))
     monkeypatch.setitem(sys.modules, 'pyautogui', types.ModuleType('pyautogui'))

--- a/tests/test_response_filter.py
+++ b/tests/test_response_filter.py
@@ -8,7 +8,6 @@ import types
 def import_assistant(monkeypatch):
     li = types.ModuleType('llm_interface')
     li.generate_response = lambda *a, **kw: 'ok'
-    li.DEFAULT_FALLBACK = "fallback"
     monkeypatch.setitem(sys.modules, 'llm_interface', li)
     monkeypatch.setitem(sys.modules, 'keyboard', types.ModuleType('keyboard'))
     monkeypatch.setitem(sys.modules, 'pyautogui', types.ModuleType('pyautogui'))


### PR DESCRIPTION
## Summary
- remove unused DEFAULT_FALLBACK constant from `llm_interface.py`
- clean up unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884042d154c8324b9c464a74464d580