### PR TITLE
Add module import sanity checker

### DIFF
--- a/sanity_check.py
+++ b/sanity_check.py
@@ -1,0 +1,55 @@
+"""Module import sanity checker for the Local Modular AI Assistant.
+
+This script attempts to import a list of core modules and prints the result for
+each. It is useful during development to ensure that optional dependencies are
+available and that there are no syntax errors preventing imports.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Iterable
+
+
+MODULES: list[str] = [
+    "assistant",
+    "orchestrator",
+    "android_gui_app",
+    "android_cli_assistant",
+    "build_apk",
+    "cleanup",
+    "vision_tools",
+    "memory_tools",
+    "voice_control",
+    "macros",
+    "tools",
+    "gui_assistant",
+    "cli_assistant",
+]
+
+
+def check_module(name: str) -> str:
+    """Import ``name`` and return a human friendly status string."""
+    try:
+        importlib.import_module(name)
+    except ImportError as exc:  # module not found or optional dependency missing
+        return f"\u274c {name}: {exc}"
+    except Exception as exc:  # pragma: no cover - unpredictable errors
+        return f"\u26a0\ufe0f {name}: {exc}"
+    return f"\u2705 {name}"
+
+
+def run_checks(mod_names: Iterable[str]) -> None:
+    """Attempt to import each module and print a status line."""
+    for mod in mod_names:
+        print(check_module(mod))
+
+
+def main() -> None:
+    """Entry point for command-line execution."""
+    run_checks(MODULES)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -1,0 +1,16 @@
+import sys
+import subprocess
+
+from sanity_check import MODULES
+
+
+def test_sanity_check_runs(tmp_path):
+    result = subprocess.run(
+        [sys.executable, 'sanity_check.py'], capture_output=True, text=True, check=True
+    )
+    lines = [l for l in result.stdout.splitlines() if l.strip()]
+    assert len(lines) == len(MODULES)
+    for line in lines:
+        assert line.startswith(('✅', '❌', '⚠️'))
+    for mod in MODULES:
+        assert any(mod in line for line in lines)


### PR DESCRIPTION
## Summary
- add a `sanity_check.py` script to verify module imports
- cover the script with a simple pytest

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840c36aab4832489cd1aae387aaf1d