### PR TITLE
Add dynamic skills plugin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,9 @@ Enable/disable plugins in config.json (enable_plugins).
 
 Load plugin packages with `modules.plugin_loader` to dynamically add new
 modules at runtime. Launch `python config_gui.py` for a quick settings editor.
+Python files placed in a `skills/` folder are automatically loaded as
+hot-swappable plugins. Any public functions they define become callable by
+name through the orchestrator.
 Use the **Edit Memory** button there or in the main GUI to view conversation
 history and adjust the `memory_max` limit.
 

--- a/skills/__init__.py
+++ b/skills/__init__.py
@@ -1,0 +1,6 @@
+"""User skill plugins auto-loaded at runtime."""
+
+from .skill_loader import SkillRegistry, registry
+
+__all__ = ["SkillRegistry", "registry"]
+

--- a/skills/skill_loader.py
+++ b/skills/skill_loader.py
@@ -1,0 +1,98 @@
+"""Dynamic loader for user skill plugins.
+
+This module automatically imports all ``.py`` files in the configured
+``skills`` directory and keeps them up to date. Public callables are
+registered so the orchestrator can invoke them by name.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from types import ModuleType
+from typing import Callable, Dict
+
+from error_logger import log_error
+
+__all__ = ["SkillRegistry", "registry"]
+
+
+class SkillRegistry:
+    """Manage skill plugin modules and their exported functions."""
+
+    def __init__(self, skills_dir: str | os.PathLike = "skills") -> None:
+        self.skills_dir = Path(skills_dir)
+        self.modules: Dict[str, ModuleType] = {}
+        self.mtimes: Dict[str, float] = {}
+        self.functions: Dict[str, Callable] = {}
+        self.load_all()
+
+    def _import_module(self, name: str, path: Path) -> ModuleType | None:
+        spec = importlib.util.spec_from_file_location(f"skills.{name}", path)
+        if not spec or not spec.loader:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+        except Exception as e:  # pragma: no cover - runtime import errors
+            log_error(f"[SkillLoader] Failed to import {name}: {e}")
+            return None
+        return mod
+
+    def _register_functions(self, name: str, mod: ModuleType) -> None:
+        names = getattr(mod, "__all__", None)
+        if names is None:
+            names = [n for n in dir(mod) if callable(getattr(mod, n)) and not n.startswith("_")]
+        for fn in names:
+            func = getattr(mod, fn, None)
+            if callable(func):
+                self.functions[fn] = func
+
+    def load_all(self) -> None:
+        """Load all skill modules from ``self.skills_dir``."""
+        if not self.skills_dir.exists():
+            return
+        for path in self.skills_dir.glob("*.py"):
+            if path.name == "__init__.py":
+                continue
+            self._load(path.stem, path)
+
+    def _load(self, name: str, path: Path) -> None:
+        mod = self._import_module(name, path)
+        if not mod:
+            return
+        self.modules[name] = mod
+        self.mtimes[name] = os.path.getmtime(path)
+        self._register_functions(name, mod)
+
+    def reload_modified(self) -> None:
+        """Reload modules that were added or changed on disk."""
+        if not self.skills_dir.exists():
+            return
+        # New or updated files
+        for path in self.skills_dir.glob("*.py"):
+            if path.name == "__init__.py":
+                continue
+            name = path.stem
+            mtime = os.path.getmtime(path)
+            if name not in self.mtimes or mtime != self.mtimes[name]:
+                self._load(name, path)
+        # Removed files
+        for name in list(self.modules):
+            path = self.skills_dir / f"{name}.py"
+            if not path.exists():
+                self.modules.pop(name, None)
+                self.mtimes.pop(name, None)
+                for fn in list(self.functions):
+                    func = self.functions[fn]
+                    if getattr(func, "__module__", "").endswith(name):
+                        self.functions.pop(fn, None)
+
+    def get_functions(self) -> Dict[str, Callable]:
+        """Return currently registered skill functions."""
+        return dict(self.functions)
+
+
+# Default registry used by the orchestrator
+registry = SkillRegistry()

--- a/tests/test_skill_integration.py
+++ b/tests/test_skill_integration.py
@@ -1,0 +1,19 @@
+import importlib
+from skills.skill_loader import SkillRegistry
+
+
+def test_orchestrator_loads_skills(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "__init__.py").write_text("")
+    (skills_dir / "hello.py").write_text("""__all__=['say']\n
+def say():\n    return 'ok'\n""")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    import orchestrator
+    orchestrator.SKILL_REGISTRY = SkillRegistry(skills_dir)
+    orchestrator._refresh_skills()
+    assert orchestrator.ALLOWED_FUNCTIONS['say']() == 'ok'
+
+
+

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import time
+from skills.skill_loader import SkillRegistry
+
+
+def test_load_and_reload(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "__init__.py").write_text("")
+    skill_file = skills_dir / "demo.py"
+    skill_file.write_text("""__all__=['greet']\n
+def greet():\n    return 'hi'\n""")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    reg = SkillRegistry(skills_dir)
+    funcs = reg.get_functions()
+    assert funcs["greet"]() == "hi"
+
+    # Modify skill and reload
+    skill_file.write_text("""__all__=['greet']\n
+def greet():\n    return 'bye'\n""")
+    time.sleep(0.1)
+    skill_file.touch()
+    reg.reload_modified()
+    assert reg.get_functions()["greet"]() == "bye"
+


### PR DESCRIPTION
## Summary
- introduce dynamic `skills` loader and registry
- integrate skills with orchestrator
- document skills folder in README
- test plugin loading and hot-swapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68840c3f8ca48324b58e920e3dbfd1a5