### PR TITLE
Add watchdog decorator for auto-restart

### DIFF
--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,50 @@
+import importlib
+import sys
+import types
+
+
+def test_watchdog_restarts_and_logs(monkeypatch):
+    logs = []
+
+    def mock_log(msg, context=None, level='ERROR'):
+        logs.append(msg)
+
+    monkeypatch.setitem(sys.modules, 'error_logger', types.ModuleType('error_logger'))
+    sys.modules['error_logger'].log_error = mock_log
+
+    wd = importlib.import_module('watchdog')
+    importlib.reload(wd)
+
+    attempts = {'n': 0}
+
+    @wd.watchdog(delay=0)
+    def flaky():
+        attempts['n'] += 1
+        if attempts['n'] < 2:
+            raise RuntimeError('boom')
+        return 'ok'
+
+    result = flaky()
+
+    assert result == 'ok'
+    assert attempts['n'] == 2
+    assert any('boom' in m for m in logs)
+
+
+def test_watchdog_announces(monkeypatch):
+    spoken = []
+
+    def mock_speak(text):
+        spoken.append(text)
+
+    wd = importlib.import_module('watchdog')
+    importlib.reload(wd)
+
+    @wd.watchdog(delay=0, phrase='restart', speak_func=mock_speak)
+    def fail_once():
+        if not spoken:
+            raise ValueError('fail')
+        return 'done'
+
+    assert fail_once() == 'done'
+    assert 'restart' in spoken[0]

--- a/watchdog.py
+++ b/watchdog.py
@@ -1,0 +1,52 @@
+"""Automatic restart decorator for critical loops/functions."""
+
+from functools import wraps
+import time
+from typing import Callable, Any, Optional
+
+from error_logger import log_error
+
+
+def watchdog(
+    delay: float = 1.0,
+    phrase: str = "Restarting module due to error",
+    speak_func: Optional[Callable[[str], Any]] = None,
+):
+    """Return a decorator that restarts ``func`` if it crashes.
+
+    Parameters
+    ----------
+    delay : float, optional
+        Seconds to wait before restarting after an error.
+    phrase : str, optional
+        Message announced via ``speak_func`` when restarting.
+    speak_func : Callable[[str], Any], optional
+        Text-to-speech function used to announce restarts.
+    """
+
+    def decorator(func: Callable):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as exc:  # pragma: no cover - runtime depends on user func
+                    log_error(f"[watchdog:{func.__name__}] {exc}")
+                    if speak_func:
+                        try:
+                            speak_func(phrase)
+                        except Exception as speak_exc:  # pragma: no cover - speak may fail
+                            log_error(f"[watchdog:speak] {speak_exc}")
+                    time.sleep(delay)
+        return wrapper
+
+    return decorator
+
+
+def get_description() -> str:
+    """Return description string for discovery."""
+
+    return (
+        "Decorator that restarts a function after logging errors and announcing via TTS."
+    )
+


### PR DESCRIPTION
## Summary
- create `watchdog` decorator that restarts failed functions after logging
- provide module description
- add tests covering restart logic and optional speech notification

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840c4464e083248580b037f31b1f17