### PR TITLE
Add command macro learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Conversation history for more contextual responses**
 - **Safe automation: tools, actions, and GUI scripting**
 - **Record and play macros on the fly for custom workflows**
+- **Teach command macros via `learn this macro <name>` and replay them later**
 - **Hotkeys tab with a macro recorder and 3-second countdown**
 - **Vision/ocr tools:** Screen capture and image recognition by voice or command
 - **Local image generation via Stable Diffusion (no cloud required; requires `diffusers` and `torch`)**
@@ -295,6 +296,7 @@ history and adjust the `memory_max` limit.
 Place custom macro scripts in the `macros/` folder. Load them at runtime with `modules.macro_loader` or record new ones from the **Hotkeys** tab in the GUI.
 You can now record a macro and automatically generate a runnable Python script using `modules.automation_learning.record_macro_script`.
 An example macro `sample_open_notepad.json` is included. Run it with `play macro sample_open_notepad`.
+Say `learn this macro <name>` in the CLI to capture your next commands as a command macro.
 Use `modules.voice_annotations.record_annotation` to add voice notes to a macro.
 Preview steps with `modules.overlay_preview.preview_macro` before saving.
 Call `modules.macro_suggestions.suggest_macros()` to see recommended macros.

--- a/modules/command_macros.py
+++ b/modules/command_macros.py
@@ -1,0 +1,104 @@
+"""Manage user-defined command macros.
+
+This module allows recording sequences of text commands
+and replaying them later. Macros are stored in
+``command_macros.json`` in the current working directory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Callable, Dict, List, Optional
+
+FILE_PATH = "command_macros.json"
+
+_current_name: Optional[str] = None
+_current_commands: List[str] = []
+
+__all__ = [
+    "start_recording",
+    "record_command",
+    "stop_recording",
+    "is_recording",
+    "list_macros",
+    "run_macro",
+    "edit_macro",
+    "get_description",
+]
+
+
+def _load() -> Dict[str, List[str]]:
+    if os.path.isfile(FILE_PATH):
+        with open(FILE_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def _save(data: Dict[str, List[str]]) -> None:
+    with open(FILE_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def start_recording(name: str) -> str:
+    """Begin recording a macro named ``name``."""
+    global _current_name, _current_commands
+    if _current_name:
+        return f"Already recording macro {_current_name}"
+    _current_name = name.strip()
+    _current_commands = []
+    return f"Recording macro '{_current_name}'. Say 'stop macro' to finish."
+
+
+def record_command(cmd: str) -> None:
+    """Append ``cmd`` to the current macro if recording."""
+    if _current_name:
+        _current_commands.append(cmd.strip())
+
+
+def stop_recording() -> str:
+    """Stop recording and persist the macro."""
+    global _current_name, _current_commands
+    if not _current_name:
+        return "Not currently recording"
+    data = _load()
+    data[_current_name] = _current_commands
+    _save(data)
+    name = _current_name
+    _current_name = None
+    _current_commands = []
+    return f"Saved macro '{name}'"
+
+
+def is_recording() -> bool:
+    return _current_name is not None
+
+
+def list_macros() -> List[str]:
+    """Return names of saved command macros."""
+    return list(_load().keys())
+
+
+def run_macro(name: str, executor: Callable[[str], str | None]) -> str:
+    """Execute each command in macro ``name`` using ``executor``."""
+    data = _load()
+    cmds = data.get(name)
+    if not cmds:
+        return f"Macro '{name}' not found"
+    for cmd in cmds:
+        executor(cmd)
+    return f"Ran macro '{name}'"
+
+
+def edit_macro(name: str, commands: List[str]) -> str:
+    """Replace ``name`` macro with ``commands``."""
+    data = _load()
+    if name not in data:
+        return f"Macro '{name}' not found"
+    data[name] = [c.strip() for c in commands]
+    _save(data)
+    return f"Updated macro '{name}'"
+
+
+def get_description() -> str:
+    return "Record and run text command macros."

--- a/tests/test_cli_command_macros.py
+++ b/tests/test_cli_command_macros.py
@@ -1,0 +1,32 @@
+import importlib
+import types
+import sys
+
+sys_modules = {
+    'keyboard': types.ModuleType('keyboard'),
+    'pyautogui': types.ModuleType('pyautogui'),
+}
+sys.modules.update(sys_modules)
+
+import cli_assistant as cli
+
+
+def test_cli_macro_learning(monkeypatch, tmp_path):
+    cm = importlib.import_module('modules.command_macros')
+    importlib.reload(cm)
+    monkeypatch.setattr(cm, 'FILE_PATH', str(tmp_path / 'cmd.json'), raising=False)
+    monkeypatch.setitem(sys.modules, 'modules.command_macros', cm)
+
+    monkeypatch.setattr(cli, 'parse_and_execute', lambda c: f'ran {c}')
+
+    out = cli.handle_cli_input('learn this macro demo')
+    assert 'Recording' in out
+    cli.handle_cli_input('open 1')
+    cli.handle_cli_input('type 2')
+    out = cli.handle_cli_input('stop macro')
+    assert 'Saved macro' in out
+    executed = []
+    monkeypatch.setattr(cli, 'parse_and_execute', lambda c: executed.append(c) or 'ok')
+    out = cli.handle_cli_input('run macro demo')
+    assert 'Ran macro' in out
+    assert executed == ['open 1', 'type 2']

--- a/tests/test_command_macros.py
+++ b/tests/test_command_macros.py
@@ -1,0 +1,19 @@
+import importlib
+from pathlib import Path
+
+
+def test_record_and_run(tmp_path, monkeypatch):
+    cm = importlib.import_module('modules.command_macros')
+    importlib.reload(cm)
+    monkeypatch.setattr(cm, 'FILE_PATH', str(tmp_path / 'cmd.json'), raising=False)
+
+    assert cm.start_recording('demo').startswith('Recording')
+    cm.record_command('open notepad')
+    cm.record_command('type hello')
+    assert cm.stop_recording() == "Saved macro 'demo'"
+    assert Path(cm.FILE_PATH).exists()
+    assert cm.list_macros() == ['demo']
+
+    executed = []
+    cm.run_macro('demo', lambda c: executed.append(c))
+    assert executed == ['open notepad', 'type hello']


### PR DESCRIPTION
## Summary
- implement `modules.command_macros` for recording sequences of text commands
- hook CLI and GUI assistants to start/stop/list/run/edit command macros
- document new feature in README
- add unit tests for command macros

## Testing
- `pytest -q tests/test_command_macros.py tests/test_cli_command_macros.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840c48d77883249f3f728509b76aba