### PR TITLE
Add live debug overlay panel

### DIFF
--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -60,6 +60,7 @@ from modules import speech_learning
 from modules.utils import resource_path
 from modules import wake_sleep_hotkey
 from modules import api_keys
+from modules import debug_panel
 from modules import image_generator
 from modules import stable_diffusion_generator as sd_generator
 from modules.browser_automation import set_webview_callback
@@ -379,6 +380,8 @@ def send():
     user_input = entry.get()
     entry.delete(0, tk.END)
     # Use imported process_input, pass the UI output widget for responses
+    if user_input.strip():
+        debug_panel.add_command(user_input)
     threading.Thread(target=process_input, args=(user_input, output), daemon=True).start()
 
 # ===== Task Entry Handlers =====
@@ -394,6 +397,7 @@ def send_task(event=None):
         return
     task_history.append(user_input)
     history_index = len(task_history)
+    debug_panel.add_command(user_input)
     threading.Thread(target=process_input, args=(user_input, output), daemon=True).start()
 
 def show_prev_task(event):
@@ -447,6 +451,20 @@ memory_button.pack(side=tk.LEFT, padx=(0, 5))
 screen_button = ttk.Button(buttons_frame, text="What's on my screen?", command=open_screen_viewer)
 
 screen_button.pack(side=tk.LEFT, padx=(0, 5))
+
+debug_window: debug_panel.DebugOverlay | None = None
+
+def toggle_debug_panel() -> None:
+    global debug_window
+    if debug_window and debug_window.winfo_exists():
+        debug_window.hide()
+        debug_window.destroy()
+        debug_window = None
+    else:
+        debug_window = debug_panel.DebugOverlay(master=root)
+
+debug_button = ttk.Button(buttons_frame, text="Debug", command=toggle_debug_panel)
+debug_button.pack(side=tk.LEFT, padx=(0, 5))
 
 
 

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -148,6 +148,11 @@ def search_memory(query, top_k=5):
     # Get top K
     idxs = np.argsort(sims)[::-1][:top_k]
     results = [f"{memory['texts'][i]} (score={sims[i]:.2f})" for i in idxs]
+    try:
+        from modules import debug_panel
+        debug_panel.add_memory_event(f"search '{query}' -> {len(results)} results")
+    except Exception:
+        pass
     return results
 
 # Auto-load at import

--- a/modules/debug_panel.py
+++ b/modules/debug_panel.py
@@ -1,0 +1,125 @@
+"""Live debug overlay for development insight."""
+
+from __future__ import annotations
+
+import os
+
+try:
+    import tkinter as tk
+    from tkinter import ttk
+except Exception:  # pragma: no cover - Tk may be unavailable
+    tk = None
+    ttk = None
+
+__all__ = [
+    "add_transcript",
+    "add_ocr_result",
+    "add_command",
+    "add_memory_event",
+    "DebugOverlay",
+]
+
+_MAX = 20
+transcripts: list[str] = []
+ocr_results: list[str] = []
+commands: list[str] = []
+memory_events: list[str] = []
+
+
+def _trim(lst: list[str]) -> None:
+    if len(lst) > _MAX:
+        del lst[:-_MAX]
+
+
+def add_transcript(text: str) -> None:
+    """Record spoken transcript for the debug panel."""
+    transcripts.append(text)
+    _trim(transcripts)
+
+
+def add_ocr_result(text: str) -> None:
+    """Record OCR output for the debug panel."""
+    ocr_results.append(text)
+    _trim(ocr_results)
+
+
+def add_command(text: str) -> None:
+    """Record a command sent to the assistant."""
+    commands.append(text)
+    _trim(commands)
+
+
+def add_memory_event(event: str) -> None:
+    """Record memory lookup or event."""
+    memory_events.append(event)
+    _trim(memory_events)
+
+
+if tk:
+
+    class DebugOverlay(tk.Toplevel):
+        """Collapsible live debug overlay."""
+
+        def __init__(self, master: tk.Misc | None = None, refresh_ms: int = 1000) -> None:
+            super().__init__(master)
+            self.title("Debug Panel")
+            self.refresh_ms = refresh_ms
+            self.geometry("400x300")
+            self.resizable(True, True)
+            self.text = tk.Text(self, wrap=tk.WORD, state=tk.DISABLED)
+            self.text.pack(fill="both", expand=True)
+            self.protocol("WM_DELETE_WINDOW", self.hide)
+            self._visible = True
+            self.after(self.refresh_ms, self.refresh)
+
+        def hide(self) -> None:
+            self.withdraw()
+            self._visible = False
+
+        def show(self) -> None:
+            self.deiconify()
+            self._visible = True
+            self.refresh()
+
+        def refresh(self) -> None:
+            if not self._visible:
+                return
+            self.text.config(state=tk.NORMAL)
+            self.text.delete("1.0", tk.END)
+            self.text.insert(tk.END, "=== Transcribed Speech ===\n")
+            for t in transcripts[-10:]:
+                self.text.insert(tk.END, f"{t}\n")
+            self.text.insert(tk.END, "\n=== OCR Results ===\n")
+            for t in ocr_results[-5:]:
+                self.text.insert(tk.END, f"{t}\n")
+            self.text.insert(tk.END, "\n=== Recent Commands ===\n")
+            for t in commands[-10:]:
+                self.text.insert(tk.END, f"{t}\n")
+            self.text.insert(tk.END, "\n=== Memory Events ===\n")
+            for t in memory_events[-10:]:
+                self.text.insert(tk.END, f"{t}\n")
+            self.text.config(state=tk.DISABLED)
+            self.after(self.refresh_ms, self.refresh)
+else:
+
+    class DebugOverlay:
+        """Fallback no-op overlay when Tkinter is unavailable."""
+
+        def __init__(self, *_, **__) -> None:
+            pass
+
+        def hide(self) -> None:  # pragma: no cover - no GUI
+            pass
+
+        def show(self) -> None:  # pragma: no cover - no GUI
+            pass
+
+        def refresh(self) -> None:  # pragma: no cover - no GUI
+            pass
+
+def get_description() -> str:
+    """Return a short summary of this module."""
+    return (
+        "Live debug overlay displaying transcripts, OCR results, recent commands "
+        "and memory events."
+    )

--- a/modules/vision_tools.py
+++ b/modules/vision_tools.py
@@ -86,6 +86,11 @@ def see_screen(monitor: int | None = None, log: bool = True):
         text = pytesseract.image_to_string(img)
         if log:
             save_ocr_log("full" if monitor is None else f"monitor_{monitor}", text)
+        try:
+            from modules import debug_panel
+            debug_panel.add_ocr_result(text.strip())
+        except Exception:
+            pass
         return f"Screen says:\n{text.strip()[:800] or 'No text found.'}"
     except Exception as e:  # pragma: no cover - safety net
         log_error(f"[vision_tools] see_screen failed: {e}")
@@ -110,6 +115,11 @@ def see_region(x: int, y: int, w: int, h: int, monitor: int | None = None, log: 
                 f"region_{x}_{y}" if monitor is None else f"monitor{monitor}_{x}_{y}"
             )
             save_ocr_log(label, text)
+        try:
+            from modules import debug_panel
+            debug_panel.add_ocr_result(text.strip())
+        except Exception:
+            pass
         return f"Region ({x},{y},{w},{h}) says:\n{text.strip()[:800] or 'No text found.'}"
     except Exception as e:  # pragma: no cover - safety net
         log_error(f"[vision_tools] see_region failed: {e}")
@@ -197,6 +207,11 @@ def analyze_image(path: str):
     try:
         img = Image.open(path)
         text = pytesseract.image_to_string(img)
+        try:
+            from modules import debug_panel
+            debug_panel.add_ocr_result(text.strip())
+        except Exception:
+            pass
         return text.strip()[:800] or "No text found."
     except Exception as e:  # pragma: no cover
         log_error(f"[vision_tools] analyze_image failed: {e}")

--- a/modules/voice_input.py
+++ b/modules/voice_input.py
@@ -218,6 +218,12 @@ def start_voice_listener(output_widget, vosk_model_path, mic_hard_muted_func, st
 
                 output_widget.insert("end", f"You (voice): {text}\n")
                 output_widget.see("end")
+                try:
+                    from modules import debug_panel
+                    debug_panel.add_transcript(text)
+                    debug_panel.add_command(text)
+                except Exception:
+                    pass
                 threading.Thread(target=process_input, args=(text, output_widget), daemon=True).start()
             else:
                 time.sleep(0.1)

--- a/state_manager.py
+++ b/state_manager.py
@@ -37,6 +37,11 @@ def update_state(**kwargs):
     state.update(kwargs)
     state.setdefault("history", []).append(kwargs)
     save_state()
+    try:
+        from modules import debug_panel
+        debug_panel.add_memory_event(f"state update: {kwargs}")
+    except Exception:
+        pass
 
 def load_actions():
     global actions

--- a/tests/test_debug_panel.py
+++ b/tests/test_debug_panel.py
@@ -1,0 +1,28 @@
+import importlib
+import os
+
+import pytest
+
+
+def test_event_lists():
+    dp = importlib.import_module("modules.debug_panel")
+    dp.add_transcript("hello")
+    dp.add_ocr_result("ocr")
+    dp.add_command("cmd")
+    dp.add_memory_event("mem")
+    assert dp.transcripts[-1] == "hello"
+    assert dp.ocr_results[-1] == "ocr"
+    assert dp.commands[-1] == "cmd"
+    assert dp.memory_events[-1] == "mem"
+
+
+@pytest.mark.skipif(os.environ.get("DISPLAY") is None, reason="GUI not available")
+def test_overlay_refresh(monkeypatch):
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "1")
+    dp = importlib.import_module("modules.debug_panel")
+    dp.transcripts.append("hi")
+    overlay = dp.DebugOverlay()
+    overlay.refresh()
+    text = overlay.text.get("1.0", "end").strip()
+    assert "hi" in text
+    overlay.destroy()


### PR DESCRIPTION
## Summary
- build a reusable debug panel to show transcripts, OCR output, commands and events
- display and toggle the debug panel from the GUI
- track speech, OCR, commands and memory calls
- integrate debug hooks across voice, vision, memory and state
- test the debug panel helpers

## Testing
- `pytest -q`
- `pytest tests/test_debug_panel.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68840c4d1e308324b6a27f09dd99318e