### PR TITLE
Add OpenAI API example with error handling

### DIFF
--- a/examples/openai_chat_example.py
+++ b/examples/openai_chat_example.py
@@ -1,0 +1,77 @@
+import logging
+import os
+from typing import Optional
+
+from dotenv import load_dotenv
+import openai
+
+# Configure basic logging to a local file
+logging.basicConfig(
+    filename="openai_chat.log",
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s: %(message)s",
+)
+
+load_dotenv()  # Load variables from .env if present
+
+
+def load_api_key() -> Optional[str]:
+    """Return the OpenAI API key from the environment."""
+    key = os.getenv("OPENAI_API_KEY")
+    if not key:
+        logging.error("OPENAI_API_KEY not found")
+        print("OpenAI API key is missing. Set OPENAI_API_KEY in your environment or .env file.")
+        return None
+
+    # Show only the first few characters so it's clear which key loaded
+    print(f"Loaded OpenAI API key: {key[:5]}...")
+    return key
+
+
+def send_test_message(text: str = "Hello") -> str:
+    """Send ``text`` to GPT-4 and return the response or error message."""
+    api_key = load_api_key()
+    if not api_key:
+        return "Missing API key"
+
+    try:
+        request_opts = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": text}],
+        }
+
+        # Support both openai v1 and v0 style APIs
+        if hasattr(openai, "OpenAI"):
+            client = openai.OpenAI(api_key=api_key)
+            resp = client.chat.completions.create(**request_opts)
+            message = resp.choices[0].message.content
+        else:
+            openai.api_key = api_key
+            resp = openai.ChatCompletion.create(**request_opts)
+            message = resp.choices[0].message["content"]
+
+        logging.info("API call succeeded")
+        return message
+    except (
+        openai.AuthenticationError,
+        openai.InvalidRequestError,
+        openai.PermissionError,
+    ) as exc:
+        logging.exception("OpenAI request failed")
+        return f"OpenAI API error: {exc}"
+    except openai.APIConnectionError as exc:
+        logging.exception("Network issue")
+        return f"Network error: {exc}"
+    except Exception as exc:  # pragma: no cover - unexpected failure
+        logging.exception("Unexpected error")
+        return f"Unexpected error: {exc}"
+
+
+def main() -> None:
+    """Run a simple test call."""
+    response = send_test_message("Hello")
+    print(f"Response: {response}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_openai_chat_example.py
+++ b/tests/test_openai_chat_example.py
@@ -1,0 +1,51 @@
+import importlib
+import sys
+
+import pytest
+
+MODULE_PATH = "examples.openai_chat_example"
+
+
+def reload_module():
+    """Reload the example module to apply environment changes."""
+    if MODULE_PATH in sys.modules:
+        del sys.modules[MODULE_PATH]
+    return importlib.import_module(MODULE_PATH)
+
+
+def test_missing_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    mod = reload_module()
+    result = mod.send_test_message("Hi")
+    assert "missing" in result.lower()
+
+
+def test_success(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    # Patch the OpenAI client to avoid network access
+    mod = reload_module()
+
+    class DummyResp:
+        class Choice:
+            def __init__(self):
+                self.message = type("msg", (), {"content": "pong"})
+
+        def __init__(self):
+            self.choices = [self.Choice()]
+
+    if hasattr(mod.openai, "OpenAI"):
+        class DummyClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            class chat:
+                class completions:
+                    @staticmethod
+                    def create(**_k):
+                        return DummyResp()
+        monkeypatch.setattr(mod.openai, "OpenAI", DummyClient)
+    else:
+        monkeypatch.setattr(mod.openai.ChatCompletion, "create", lambda **_k: DummyResp())
+
+    result = mod.send_test_message("Ping")
+    assert result == "pong"


### PR DESCRIPTION
## Summary
- add a sample script `openai_chat_example.py` showing how to load the API key from `.env`, make a GPT‑4 call and handle errors
- log successful calls and failures to a file
- include tests that exercise the example module without network usage

## Testing
- `ruff check examples/openai_chat_example.py tests/test_openai_chat_example.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884148ba2508324aa90ed9522ddd006