### PR TITLE
Add plugin registry for skills

### DIFF
--- a/plugin_loader.py
+++ b/plugin_loader.py
@@ -1,0 +1,83 @@
+"""Dynamic plugin loader for skill modules.
+
+This module loads all Python files from the configured ``skills`` directory,
+imports their top-level callables, and registers them in a global registry.
+Modules without any callable functions are ignored. When initialized, it prints
+all loaded plugin names and their exported functions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from types import ModuleType
+from typing import Callable, Dict
+
+from error_logger import log_error
+
+__all__ = ["PluginRegistry", "registry"]
+
+
+class PluginRegistry:
+    """Manage loading and registration of skill plugins."""
+
+    def __init__(self, skills_dir: str | os.PathLike = "skills") -> None:
+        self.skills_dir = Path(skills_dir)
+        self.modules: Dict[str, ModuleType] = {}
+        self.functions: Dict[str, Callable] = {}
+        self.load_all()
+        if self.functions:
+            self._print_summary()
+
+    # internal helpers -------------------------------------------------
+    def _import_module(self, name: str, path: Path) -> ModuleType | None:
+        spec = importlib.util.spec_from_file_location(f"skills.{name}", path)
+        if not spec or not spec.loader:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+        except Exception as e:  # pragma: no cover - runtime errors
+            log_error(f"[plugin_loader] Failed to import {name}: {e}")
+            return None
+        return mod
+
+    def _register_functions(self, name: str, mod: ModuleType) -> bool:
+        funcs = {
+            fn: getattr(mod, fn)
+            for fn in dir(mod)
+            if callable(getattr(mod, fn)) and not fn.startswith("_")
+        }
+        if not funcs:
+            return False
+        self.modules[name] = mod
+        self.functions.update(funcs)
+        return True
+
+    def _print_summary(self) -> None:
+        print("[PluginLoader] Loaded plugins:")
+        for mod_name, mod in self.modules.items():
+            funcs = [fn for fn in dir(mod) if callable(getattr(mod, fn)) and not fn.startswith("_")]
+            print(f"  - {mod_name}: {', '.join(funcs)}")
+
+    # public API -------------------------------------------------------
+    def load_all(self) -> None:
+        """Load all plugins from ``self.skills_dir``."""
+        if not self.skills_dir.exists():
+            return
+        for path in self.skills_dir.glob("*.py"):
+            if path.name == "__init__.py":
+                continue
+            name = path.stem
+            mod = self._import_module(name, path)
+            if mod:
+                self._register_functions(name, mod)
+
+    def get_functions(self) -> Dict[str, Callable]:
+        """Return a mapping of function names to callables."""
+        return dict(self.functions)
+
+
+# Global registry instance used throughout the assistant
+registry = PluginRegistry()

--- a/tests/test_new_plugin_loader.py
+++ b/tests/test_new_plugin_loader.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import importlib
+
+from plugin_loader import PluginRegistry
+
+
+def test_plugin_registry_loads_functions(tmp_path, capsys, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "__init__.py").write_text("")
+    (skills_dir / "skill_a.py").write_text("def greet():\n    return 'hi'\n")
+    (skills_dir / "empty.py").write_text("value = 1\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    registry = PluginRegistry(skills_dir)
+    funcs = registry.get_functions()
+    assert funcs["greet"]() == "hi"
+    assert "empty" not in registry.modules
+
+    out = capsys.readouterr().out
+    assert "skill_a" in out and "greet" in out
+


### PR DESCRIPTION
## Summary
- implement `PluginRegistry` to auto-load skills from `/skills`
- print plugin and function names at startup
- test loading and registration of plugin functions

## Testing
- `pytest -q tests/test_new_plugin_loader.py`
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6884171191208324aa053e91c3b3a392