### PR TITLE
Add utility modules and tests

### DIFF
--- a/debug_overlay.py
+++ b/debug_overlay.py
@@ -1,0 +1,122 @@
+"""Optional GUI overlay for debugging assistant state."""
+
+from __future__ import annotations
+
+from typing import List
+
+try:
+    import tkinter as tk
+except Exception:  # pragma: no cover - tk may be missing
+    tk = None
+
+__all__ = [
+    "add_transcript",
+    "add_ocr_text",
+    "add_command",
+    "add_memory_recall",
+    "DebugOverlay",
+]
+
+_transcripts: List[str] = []
+_ocr_texts: List[str] = []
+_commands: List[str] = []
+_memory: List[str] = []
+_MAX = 20
+
+
+def _trim(lst: List[str]) -> None:
+    if len(lst) > _MAX:
+        del lst[:-_MAX]
+
+
+def add_transcript(text: str) -> None:
+    _transcripts.append(text)
+    _trim(_transcripts)
+
+
+def add_ocr_text(text: str) -> None:
+    _ocr_texts.append(text)
+    _trim(_ocr_texts)
+
+
+def add_command(text: str) -> None:
+    _commands.append(text)
+    _trim(_commands)
+
+
+def add_memory_recall(text: str) -> None:
+    _memory.append(text)
+    _trim(_memory)
+
+
+if tk:
+
+    class DebugOverlay(tk.Toplevel):
+        """Floating window showing live debug information."""
+
+        def __init__(self, master: tk.Misc | None = None, refresh_ms: int = 1000) -> None:
+            super().__init__(master)
+            self.withdraw()
+            self.refresh_ms = refresh_ms
+            self.title("Debug Overlay")
+            self.geometry("600x400")
+            self.transient(master)
+            self.attributes("-topmost", True)
+
+            self.txt_trans = tk.Text(self, height=5, state=tk.DISABLED)
+            self.txt_ocr = tk.Text(self, height=5, state=tk.DISABLED)
+            self.txt_cmd = tk.Text(self, height=5, state=tk.DISABLED)
+            self.txt_mem = tk.Text(self, height=5, state=tk.DISABLED)
+
+            self.txt_trans.grid(row=0, column=0, sticky="nsew")
+            self.txt_ocr.grid(row=0, column=1, sticky="nsew")
+            self.txt_mem.grid(row=1, column=0, columnspan=2, sticky="nsew")
+            self.txt_cmd.grid(row=2, column=0, columnspan=2, sticky="nsew")
+
+            self.grid_rowconfigure(0, weight=1)
+            self.grid_rowconfigure(1, weight=1)
+            self.grid_rowconfigure(2, weight=1)
+            self.grid_columnconfigure(0, weight=1)
+            self.grid_columnconfigure(1, weight=1)
+
+            self._visible = False
+            self.after(self.refresh_ms, self.refresh)
+
+        def toggle(self) -> None:
+            if self._visible:
+                self.withdraw()
+                self._visible = False
+            else:
+                self.deiconify()
+                self._visible = True
+                self.refresh()
+
+        def refresh(self) -> None:
+            if not self._visible:
+                self.after(self.refresh_ms, self.refresh)
+                return
+            self._update_text(self.txt_trans, _transcripts, "Transcription")
+            self._update_text(self.txt_ocr, _ocr_texts, "OCR")
+            self._update_text(self.txt_cmd, _commands, "Commands")
+            self._update_text(self.txt_mem, _memory, "Memory")
+            self.after(self.refresh_ms, self.refresh)
+
+        def _update_text(self, widget: tk.Text, data: List[str], title: str) -> None:
+            widget.config(state=tk.NORMAL)
+            widget.delete("1.0", tk.END)
+            widget.insert(tk.END, f"=== {title} ===\n")
+            for item in data[-5:]:
+                widget.insert(tk.END, f"{item}\n")
+            widget.config(state=tk.DISABLED)
+
+else:
+
+    class DebugOverlay:
+        def __init__(self, *_, **__) -> None:
+            self._visible = False
+
+        def toggle(self) -> None:  # pragma: no cover - no GUI
+            self._visible = not self._visible
+
+        def refresh(self) -> None:  # pragma: no cover - no GUI
+            pass

--- a/initialize_skills_folder.py
+++ b/initialize_skills_folder.py
@@ -1,0 +1,29 @@
+"""Utility to ensure the skills folder exists on startup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from error_logger import log_info, log_error
+
+__all__ = ["initialize_skills_folder"]
+
+
+def initialize_skills_folder(path: str | Path = "skills") -> None:
+    """Create the skills folder with example files if missing."""
+    skills_path = Path(path)
+    if skills_path.exists():
+        return
+    try:
+        skills_path.mkdir(parents=True, exist_ok=True)
+        (skills_path / "__init__.py").write_text("\n")
+        (skills_path / "example_skill.py").write_text(
+            """__all__=['hello']\n
+def hello():\n    return 'hello world'\n"""
+        )
+        log_info("Skills folder initialized.")
+    except Exception as exc:  # pragma: no cover - filesystem errors
+        log_error(
+            f"[initialize_skills_folder] failed to create skills folder: {exc}"
+        )
+

--- a/macro_learning.py
+++ b/macro_learning.py
@@ -1,0 +1,78 @@
+"""Voice macro learning system for assistant commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, List, Iterable
+
+from error_logger import log_error
+
+MACRO_DIR = "macros"
+
+__all__ = ["learn_macro", "run_macro"]
+
+
+def learn_macro(
+    get_command: Callable[[], str],
+    steps: int = 5,
+    on_prompt: Callable[[str], None] | None = None,
+) -> Path | None:
+    """Record ``steps`` commands using ``get_command`` and save as a macro.
+
+    Parameters
+    ----------
+    get_command:
+        Callable returning the next command string from the assistant.
+    steps:
+        Number of commands to record before asking for the macro name.
+    on_prompt:
+        Optional callback to present prompts to the user (e.g. TTS or print).
+
+    Returns
+    -------
+    Path | None
+        Path to the saved macro file or ``None`` if cancelled.
+    """
+    cmds: List[str] = []
+    for _ in range(steps):
+        cmd = get_command().strip()
+        if cmd.lower() == "cancel":
+            if on_prompt:
+                on_prompt("Macro recording cancelled.")
+            return None
+        cmds.append(cmd)
+    if on_prompt:
+        on_prompt("Please provide a name for this macro or say cancel.")
+    name = get_command().strip()
+    if not name or name.lower() == "cancel":
+        if on_prompt:
+            on_prompt("Macro recording cancelled.")
+        return None
+    Path(MACRO_DIR).mkdir(exist_ok=True)
+    path = Path(MACRO_DIR) / f"{name}.json"
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(cmds, f, indent=2)
+    except Exception as exc:  # pragma: no cover - disk errors
+        log_error(f"[macro_learning] failed to save {name}: {exc}")
+        return None
+    if on_prompt:
+        on_prompt(f"Saved macro {name}.")
+    return path
+
+
+def run_macro(name: str, executor: Callable[[str], None]) -> str:
+    """Run macro ``name`` executing each command via ``executor``."""
+    path = Path(MACRO_DIR) / f"{name}.json"
+    if not path.exists():
+        return f"Macro '{name}' not found"
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            commands: Iterable[str] = json.load(f)
+    except Exception as exc:  # pragma: no cover - json errors
+        log_error(f"[macro_learning] failed to load {name}: {exc}")
+        return f"Error running macro {name}"
+    for cmd in commands:
+        executor(cmd)
+    return f"Ran macro {name}"

--- a/tests/test_debug_overlay.py
+++ b/tests/test_debug_overlay.py
@@ -1,0 +1,29 @@
+import importlib
+import os
+import pytest
+
+
+def test_event_lists():
+    do = importlib.import_module('debug_overlay')
+    do.add_transcript('hi')
+    do.add_ocr_text('ocr')
+    do.add_command('cmd')
+    do.add_memory_recall('mem')
+    assert do._transcripts[-1] == 'hi'
+    assert do._ocr_texts[-1] == 'ocr'
+    assert do._commands[-1] == 'cmd'
+    assert do._memory[-1] == 'mem'
+
+
+@pytest.mark.skipif(os.environ.get('DISPLAY') is None, reason='GUI not available')
+def test_overlay_toggle(monkeypatch):
+    monkeypatch.setenv('PYTEST_CURRENT_TEST', '1')
+    do = importlib.import_module('debug_overlay')
+    overlay = do.DebugOverlay()
+    overlay.toggle()
+    overlay.refresh()
+    text = overlay.txt_trans.get('1.0', 'end').strip()
+    assert 'Transcription' in text
+    overlay.toggle()
+    overlay.destroy()
+

--- a/tests/test_initialize_skills_folder.py
+++ b/tests/test_initialize_skills_folder.py
@@ -1,0 +1,13 @@
+import importlib
+from pathlib import Path
+
+
+def test_initialize(tmp_path, monkeypatch):
+    init_mod = importlib.import_module('initialize_skills_folder')
+    monkeypatch.chdir(tmp_path)
+    init_mod.initialize_skills_folder('skills')
+    skills = Path('skills')
+    assert skills.exists()
+    assert (skills / '__init__.py').exists()
+    assert (skills / 'example_skill.py').exists()
+

--- a/tests/test_macro_learning.py
+++ b/tests/test_macro_learning.py
@@ -1,0 +1,17 @@
+import importlib
+
+
+def test_learn_and_run(tmp_path):
+    ml = importlib.import_module('macro_learning')
+    importlib.reload(ml)
+    ml.MACRO_DIR = str(tmp_path)
+
+    cmds = iter(['one', 'two', 'three', 'demo'])
+    path = ml.learn_macro(lambda: next(cmds), steps=3)
+    assert path and path.exists()
+
+    executed = []
+    result = ml.run_macro('demo', lambda c: executed.append(c))
+    assert 'Ran macro' in result
+    assert executed == ['one', 'two', 'three']
+

--- a/watchdog.py
+++ b/watchdog.py
@@ -2,6 +2,7 @@
 
 from functools import wraps
 import time
+import traceback
 from typing import Callable, Any, Optional
 
 from error_logger import log_error
@@ -31,12 +32,16 @@ def watchdog(
                 try:
                     return func(*args, **kwargs)
                 except Exception as exc:  # pragma: no cover - runtime depends on user func
-                    log_error(f"[watchdog:{func.__name__}] {exc}")
+                    log_error(
+                        f"[watchdog:{func.__name__}] {exc}\n{traceback.format_exc()}"
+                    )
                     if speak_func:
                         try:
                             speak_func(phrase)
                         except Exception as speak_exc:  # pragma: no cover - speak may fail
                             log_error(f"[watchdog:speak] {speak_exc}")
+                    else:
+                        print(phrase)
                     time.sleep(delay)
         return wrapper
 


### PR DESCRIPTION
## Summary
- enhance `watchdog` decorator with traceback logging and restart message
- implement `macro_learning` for recording and running command macros
- add `debug_overlay` with live transcript, OCR, command and memory widgets
- create `initialize_skills_folder` to bootstrap a skills package
- cover new modules with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688417ce98688324ac563a26a6a33561