### PR TITLE
Fix module registration and remove leaked API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ __pycache__/
 *.log
 *.db
 
+# Local secrets
+.env
+config.local.json
+
 # Local state files
 assistant_memory.json
 assistant_state.json

--- a/README.md
+++ b/README.md
@@ -189,6 +189,16 @@ Key options:
 - `min_good_response_words` / `min_good_response_chars`: treat a local
   response as poor quality if shorter than these thresholds.
 
+### API Key Setup
+The `api_keys` section of `config.json` is intentionally left blank. Set your
+credentials using environment variables or with `modules/api_keys.py`:
+
+```bash
+export OPENAI_API_KEY=your-key-here
+python -m modules.api_keys save_api_keys '{"openai": "your-key"}'
+```
+Add a `.env` file if desired, but keep it out of version control.
+
 ### Remote Ollama Server
 You can run the LLM on another machine and point the assistant to it over
 your local network:

--- a/config.json
+++ b/config.json
@@ -56,7 +56,7 @@
   "home_assistant_token": "",
   "enable_home_assistant": false,
   "api_keys": {
-    "openai": "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",
+    "openai": "",
     "anthropic": "",
     "google": ""
   }

--- a/examples/openai_chat_example.py
+++ b/examples/openai_chat_example.py
@@ -1,14 +1,23 @@
 
 """Minimal script to confirm your OpenAI key and connection."""
-
-
-main
 import logging
 import os
 from typing import Optional
 
-from dotenv import load_dotenv
-import openai
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    def load_dotenv() -> None:
+        pass
+
+try:
+    import openai
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    import types
+    openai = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=lambda **_k: None),
+        OpenAI=None,
+    )
 
 # Configure basic logging to a local file
 logging.basicConfig(

--- a/generate_module.py
+++ b/generate_module.py
@@ -48,9 +48,10 @@ def get_info():
         ]
     }}
 
-def register():
+def register(registry=None):
     from module_manager import ModuleRegistry
-    ModuleRegistry.register("{module_name}", {{
+    registry = registry or ModuleRegistry()
+    registry.register("{module_name}", {{
         "initialize": initialize,
         "get_status": get_status,
         "main_function": main_function,

--- a/modules/audio_tools.py
+++ b/modules/audio_tools.py
@@ -147,11 +147,12 @@ def get_description() -> str:
     return "Capture system audio to detect sounds or transcribe speech."
 
 
-def register():
+def register(registry=None):
     """Register this module with ``ModuleRegistry``."""
     from module_manager import ModuleRegistry
 
-    ModuleRegistry.register(
+    registry = registry or ModuleRegistry()
+    registry.register(
         MODULE_NAME,
         {
             "transcribe_speaker": transcribe_speaker,

--- a/modules/automation_actions.py
+++ b/modules/automation_actions.py
@@ -105,16 +105,20 @@ def get_description() -> str:
     return "Provides drag-drop, window resize and clipboard utilities via pyautogui."
 
 
-def register():
-    """Register this module with the plugin manager."""
+def register(registry=None):
+    """Register this module with ``ModuleRegistry``."""
     from module_manager import ModuleRegistry
 
-    ModuleRegistry.register(MODULE_NAME, {
-        "drag_drop": drag_drop,
-        "resize_window": resize_window,
-        "copy_to_clipboard": copy_to_clipboard,
-        "get_clipboard": get_clipboard,
-        "get_info": get_info,
-    })
+    registry = registry or ModuleRegistry()
+    registry.register(
+        MODULE_NAME,
+        {
+            "drag_drop": drag_drop,
+            "resize_window": resize_window,
+            "copy_to_clipboard": copy_to_clipboard,
+            "get_clipboard": get_clipboard,
+            "get_info": get_info,
+        },
+    )
 
 # register()  # Optional auto-registration

--- a/modules/automation_learning.py
+++ b/modules/automation_learning.py
@@ -200,10 +200,11 @@ def get_description() -> str:
     return "Allows recording and playback of desktop macros taught by the user."
 
 
-def register():  # pragma: no cover - simple registration
+def register(registry=None):  # pragma: no cover - simple registration
     from module_manager import ModuleRegistry
 
-    ModuleRegistry.register(
+    registry = registry or ModuleRegistry()
+    registry.register(
         MODULE_NAME,
         {
             "record_events": record_events,

--- a/modules/gamebar_capture.py
+++ b/modules/gamebar_capture.py
@@ -87,10 +87,11 @@ def get_description() -> str:
     return "Operate the Xbox Game Bar capture widget via hotkeys."
 
 
-def register():
+def register(registry=None):
     from module_manager import ModuleRegistry
 
-    ModuleRegistry.register(
+    registry = registry or ModuleRegistry()
+    registry.register(
         MODULE_NAME,
         {
             "open_capture": open_capture,

--- a/modules/llm_module.py
+++ b/modules/llm_module.py
@@ -23,6 +23,8 @@ def get_description() -> str:
     return "Wrapper around llm_interface for chatting with the local LLM backend."
 
 
-def register():  # pragma: no cover - simple delegation
+def register(registry=None):  # pragma: no cover - simple delegation
     from module_manager import ModuleRegistry
-    ModuleRegistry.register(MODULE_NAME, {"chat": chat, "get_info": get_info})
+
+    registry = registry or ModuleRegistry()
+    registry.register(MODULE_NAME, {"chat": chat, "get_info": get_info})

--- a/modules/long_term_storage.py
+++ b/modules/long_term_storage.py
@@ -65,10 +65,12 @@ def get_description() -> str:
     return "Stores and retrieves conversation history in a local SQLite database."
 
 
-def register():
+def register(registry=None):
     """Register this module with ``ModuleRegistry``."""
     from module_manager import ModuleRegistry
-    ModuleRegistry.register(
+
+    registry = registry or ModuleRegistry()
+    registry.register(
         "long_term_storage",
         {
             "initialize": initialize,

--- a/modules/media_controls.py
+++ b/modules/media_controls.py
@@ -136,10 +136,11 @@ def get_description() -> str:
     return "Send OS media keys for play/pause, track skipping and volume."
 
 
-def register():
+def register(registry=None):
     from module_manager import ModuleRegistry
 
-    ModuleRegistry.register(
+    registry = registry or ModuleRegistry()
+    registry.register(
         MODULE_NAME,
         {
             "play_pause": play_pause,

--- a/modules/pyautogui_tools.py
+++ b/modules/pyautogui_tools.py
@@ -130,21 +130,24 @@ def get_description() -> str:
     return "Low-level screen automation using pyautogui for clicking, typing and screenshots."
 
 # --- Plugin Registration ---
-def register():
-    """
-    Register this module's functions with the assistant's plugin system.
-    """
+def register(registry=None):
+    """Register this module's functions with the assistant."""
     from module_manager import ModuleRegistry
-    ModuleRegistry.register(MODULE_NAME, {
-        "click": click,
-        "move": move,
-        "type_text": type_text,
-        "press": press,
-        "screenshot": screenshot,
-        "locate_on_screen": locate_on_screen,
-        "get_mouse_position": get_mouse_position,
-        "get_info": get_info
-    })
+
+    registry = registry or ModuleRegistry()
+    registry.register(
+        MODULE_NAME,
+        {
+            "click": click,
+            "move": move,
+            "type_text": type_text,
+            "press": press,
+            "screenshot": screenshot,
+            "locate_on_screen": locate_on_screen,
+            "get_mouse_position": get_mouse_position,
+            "get_info": get_info,
+        },
+    )
 
 # Uncomment if you want auto-registration:
 # register()

--- a/modules/speech_learning.py
+++ b/modules/speech_learning.py
@@ -172,10 +172,11 @@ def get_description() -> str:
     return "Practice speech recognition by reading sample sentences."
 
 
-def register():
+def register(registry=None):
     from module_manager import ModuleRegistry
 
-    ModuleRegistry.register(
+    registry = registry or ModuleRegistry()
+    registry.register(
         MODULE_NAME,
         {
             "read_sentences": read_sentences,

--- a/modules/system_volume.py
+++ b/modules/system_volume.py
@@ -74,11 +74,12 @@ def get_description() -> str:
     return "Control the system master volume level."
 
 
-def register():
+def register(registry=None):
     """Register this module with ``ModuleRegistry``."""
     from module_manager import ModuleRegistry
 
-    ModuleRegistry.register(
+    registry = registry or ModuleRegistry()
+    registry.register(
         MODULE_NAME,
         {
             "set_volume": set_volume,

--- a/modules/tts_integration.py
+++ b/modules/tts_integration.py
@@ -236,19 +236,24 @@ def get_description() -> str:
     """Return a short description of this module."""
     return "Provides offline text-to-speech playback using Coqui TTS."
 
-def register():
+def register(registry=None):
     """Register with assistant plugin system."""
     from module_manager import ModuleRegistry
-    ModuleRegistry.register(MODULE_NAME, {
-        "speak": speak,
-        "list_voices": list_voices,
-        "set_voice": set_voice,
-        "set_volume": set_volume,
-        "set_speed": set_speed,
-        "is_speaking": is_speaking,
-        "stop_speech": stop_speech,
-        "get_info": get_info
-    })
+
+    registry = registry or ModuleRegistry()
+    registry.register(
+        MODULE_NAME,
+        {
+            "speak": speak,
+            "list_voices": list_voices,
+            "set_voice": set_voice,
+            "set_volume": set_volume,
+            "set_speed": set_speed,
+            "is_speaking": is_speaking,
+            "stop_speech": stop_speech,
+            "get_info": get_info,
+        },
+    )
 
 # Optionally enable auto-registration if your loader supports it:
 # register()

--- a/modules/vosk_integration.py
+++ b/modules/vosk_integration.py
@@ -78,10 +78,12 @@ def get_description() -> str:
     """Return a short description of this module."""
     return "Simple Vosk-based offline speech recognition helper functions."
 
-def register():
+def register(registry=None):
     """Register this module with ``ModuleRegistry``."""
     from module_manager import ModuleRegistry
-    ModuleRegistry.register(
+
+    registry = registry or ModuleRegistry()
+    registry.register(
         MODULE_NAME,
         {
             "recognize_from_mic": recognize_from_mic,


### PR DESCRIPTION
## Summary
- sanitize `config.json` by clearing API keys
- document API key configuration in README
- ignore `.env` and other local secret files
- implement `ModuleRegistry.register`, `get_functions`, and fix `_register_public_functions`
- update all modules and generator to use the new registration API
- clean up `openai_chat_example` and make it optional
- add unit tests for the registry

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841e69f0708324933d392235ba48d1