### PR TITLE
Fix LLM tool call parsing

### DIFF
--- a/examples/openai_chat_example.py
+++ b/examples/openai_chat_example.py
@@ -1,8 +1,5 @@
 
 """Minimal script to confirm your OpenAI key and connection."""
-
-
-main
 import logging
 import os
 from typing import Optional


### PR DESCRIPTION
## Summary
- parse tool calls even when the LLM adds extra text
- add regression test for orchestration
- clean up `openai_chat_example.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688426f6783c8324a7e4d8ae65e64c7e