### PR TITLE
Add maximize window function with alt-tab focus fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **List open windows via the taskbar (e.g. "what windows are open?")**
 - **Minimize windows by title (e.g. "minimize YouTube Music")**
 - **Maximize windows by title (e.g. "maximize Chrome")**
-- **Focus windows by title with Alt+Tab fallback (e.g. "focus Spotify")**
+- **Focus windows by title with Alt+Tab/Cmd+Tab fallback (e.g. "focus Spotify")**
 - **Type text into any window by title (e.g. "type hello in Notepad")**
 - **Control music playback with media keys (play/pause, skip) using keyboard, Windows API, or pyautogui fallbacks**
 - **Control Xbox Game Bar capture:** open the overlay, start/stop recording, take screenshots, or capture the last 30 seconds

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Close or terminate apps by window title or process name (e.g. "terminate Rocket League")**
 - **List open windows via the taskbar (e.g. "what windows are open?")**
 - **Minimize windows by title (e.g. "minimize YouTube Music")**
-- **Focus windows by title (e.g. "focus Spotify")**
+- **Maximize windows by title (e.g. "maximize Chrome")**
+- **Focus windows by title with Alt+Tab fallback (e.g. "focus Spotify")**
 - **Type text into any window by title (e.g. "type hello in Notepad")**
 - **Control music playback with media keys (play/pause, skip) using keyboard, Windows API, or pyautogui fallbacks**
 - **Control Xbox Game Bar capture:** open the overlay, start/stop recording, take screenshots, or capture the last 30 seconds

--- a/modules/window_tools.py
+++ b/modules/window_tools.py
@@ -22,6 +22,7 @@ from modules import vision_tools
 __all__ = [
     "focus_window",
     "minimize_window",
+    "maximize_window",
     "list_windows",
     "move_window",
     "move_window_to_monitor",
@@ -134,16 +135,44 @@ def close_taskbar_item(index: int):
         return False, f"All close attempts failed for '{win.title}': {e}"
 
 def focus_window(partial_title):
-    """Bring the first window matching ``partial_title`` to the front."""
+    """Bring the first window matching ``partial_title`` to the front.
+
+    Falls back to cycling windows with ``Alt+Tab`` if a direct match is not
+    found via ``pygetwindow``.
+    """
     if _IMPORT_ERROR:
         return False, f"pygetwindow not available: {_IMPORT_ERROR}"
-    matches = [w for w in gw.getAllTitles() if partial_title.lower() in w.lower()]
-    if not matches:
+    try:
+        matches = [w for w in gw.getAllTitles() if partial_title.lower() in w.lower()]
+    except Exception:
+        matches = []
+    if matches:
+        win = gw.getWindowsWithTitle(matches[0])[0]
+        try:
+            win.activate()
+            time.sleep(0.5)
+            return True, f"Activated window: {matches[0]}"
+        except Exception:
+            pass
+
+    if _PYAUTOGUI_ERROR:
         return False, f"No window found containing '{partial_title}'"
-    win = gw.getWindowsWithTitle(matches[0])[0]
-    win.activate()
-    time.sleep(0.5)
-    return True, f"Activated window: {matches[0]}"
+
+    for _ in range(10):  # attempt a few Alt+Tab cycles
+        try:
+            pyautogui.hotkey('alt', 'tab')
+            time.sleep(0.2)
+            active = None
+            try:
+                active = gw.getActiveWindow()
+            except Exception:
+                pass
+            if active and partial_title.lower() in active.title.lower():
+                return True, f"Activated window via Alt+Tab: {active.title}"
+        except Exception:
+            break
+
+    return False, f"No window found containing '{partial_title}'"
 
 def move_window(title, x, y):
     """Move the first window matching title to (x, y)."""
@@ -189,6 +218,44 @@ def minimize_window(partial_title: str):
         return True, f"Minimized window: {matches[0]}"
     except Exception as e:  # pragma: no cover - OS specific
         return False, f"Failed to minimize '{matches[0]}': {e}"
+
+def maximize_window(partial_title: str) -> tuple[bool, str]:
+    """Maximize or full-screen the first window matching ``partial_title``.
+
+    The window is focused first (with ``Alt+Tab`` fallback) then maximized using
+    the native API. If that fails, a platform-specific hotkey is attempted.
+    """
+    if _IMPORT_ERROR:
+        return False, f"pygetwindow not available: {_IMPORT_ERROR}"
+
+    ok, msg = focus_window(partial_title)
+    if not ok:
+        return False, msg
+
+    win = gw.getActiveWindow()
+    if not win:
+        return False, f"Could not activate '{partial_title}'"
+
+    try:
+        if hasattr(win, "maximize"):
+            win.maximize()
+            return True, f"Maximized window: {win.title}"
+    except Exception:
+        pass
+
+    if _PYAUTOGUI_ERROR:
+        return False, f"Failed to maximize '{win.title}'"
+
+    try:
+        if platform.system() == "Windows":
+            pyautogui.hotkey("alt", "space")
+            time.sleep(0.1)
+            pyautogui.press("x")
+        else:
+            pyautogui.press("f11")
+        return True, f"Maximized window via hotkey: {win.title}"
+    except Exception as e:  # pragma: no cover - OS specific
+        return False, f"Failed to maximize '{win.title}': {e}"
 
 def type_in_window(partial_title: str, text: str) -> tuple[bool, str]:
     """Focus ``partial_title`` window and type ``text`` into it."""
@@ -247,6 +314,7 @@ def get_info():
         "functions": [
             "focus_window",
             "minimize_window",
+            "maximize_window",
             "list_windows",
             "move_window",
             "move_window_to_monitor",
@@ -260,7 +328,7 @@ def get_info():
 def get_description() -> str:
     """Return a short summary of this module."""
     return (
-        "Utilities for listing taskbar windows, focusing them, moving or "
-        "minimizing windows, relocating them between monitors, typing into "
-        "a window, and closing by index."
+        "Utilities for listing taskbar windows, focusing them with an Alt+Tab "
+        "fallback, maximizing or minimizing windows, relocating them between "
+        "monitors, typing into a window, and closing by index."
     )

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -175,6 +175,21 @@ def _handle_focus_alias(text: str) -> str | None:
         return f"Error running focus_window: {e}"
 
 
+def _handle_maximize_alias(text: str) -> str | None:
+    """Support ``maximize <window>`` as alias for ``maximize_window``."""
+    target = _extract_window_target(text, "maximize")
+    if not target:
+        return None
+    if "maximize_window" not in ALLOWED_FUNCTIONS:
+        return talk_to_llm(text)
+    func = ALLOWED_FUNCTIONS["maximize_window"]
+    try:
+        success, msg = func(target)
+        return msg
+    except Exception as e:
+        return f"Error running maximize_window: {e}"
+
+
 def _handle_move_window_alias(text: str) -> str | None:
     """Support ``move <title> to monitor N`` commands."""
     m = re.match(r"move\s+(.+?)\s+(?:to|onto)\s+(?:monitor|screen)\s+(\d+)", text, re.IGNORECASE)
@@ -283,6 +298,7 @@ def parse_and_execute(user_text: str) -> str:
         _handle_run_skill,
         _handle_terminate_alias,
         _handle_minimize_alias,
+        _handle_maximize_alias,
         _handle_focus_alias,
         _handle_move_window_alias,
         _handle_save_exit_alias,

--- a/tests/test_maximize_alias.py
+++ b/tests/test_maximize_alias.py
@@ -1,0 +1,26 @@
+import importlib
+import types
+import sys
+
+
+def test_parse_and_execute_maximize(monkeypatch):
+    wt = types.ModuleType('modules.window_tools')
+    calls = {}
+
+    def mock_maximize(title):
+        calls['title'] = title
+        return True, f"maximized {title}"
+
+    wt.maximize_window = mock_maximize
+    wt.__all__ = ['maximize_window']
+    monkeypatch.setitem(sys.modules, 'modules.window_tools', wt)
+
+    stub_assistant = types.ModuleType('assistant')
+    stub_assistant.talk_to_llm = lambda t: 'ignored'
+    monkeypatch.setitem(sys.modules, 'assistant', stub_assistant)
+
+    orch = importlib.reload(importlib.import_module('orchestrator'))
+
+    result = orch.parse_and_execute('maximize chrome window')
+    assert result == 'maximized chrome'
+    assert calls['title'] == 'chrome'

--- a/tests/test_window_tools.py
+++ b/tests/test_window_tools.py
@@ -167,7 +167,7 @@ def test_focus_window_alt_tab(monkeypatch):
 
     ok, msg = wt.focus_window('music')
     assert ok
-    assert ('alt', 'tab') in actions
+    assert tuple(actions[0]) == wt._ALT_TAB_KEYS
     assert 'music' in msg.lower()
 
 

--- a/tests/test_window_tools.py
+++ b/tests/test_window_tools.py
@@ -142,3 +142,72 @@ def test_focus_window_success(monkeypatch):
     assert ok
     assert mock_win.activated
     assert 'activated' in msg.lower()
+
+
+def test_focus_window_alt_tab(monkeypatch):
+    wt = importlib.import_module('modules.window_tools')
+
+    class MockGW:
+        def __init__(self):
+            self.calls = 0
+        def getAllTitles(self):
+            return []
+        def getActiveWindow(self):
+            self.calls += 1
+            if self.calls > 1:
+                return types.SimpleNamespace(title='Music App')
+            return types.SimpleNamespace(title='Other')
+
+    actions = []
+    monkeypatch.setattr(wt, 'gw', MockGW())
+    monkeypatch.setattr(wt, '_IMPORT_ERROR', None)
+    monkeypatch.setattr(wt, '_PYAUTOGUI_ERROR', None)
+    monkeypatch.setattr(wt, 'pyautogui', types.SimpleNamespace(hotkey=lambda *k: actions.append(k)))
+    monkeypatch.setattr(wt.time, 'sleep', lambda t: None)
+
+    ok, msg = wt.focus_window('music')
+    assert ok
+    assert ('alt', 'tab') in actions
+    assert 'music' in msg.lower()
+
+
+def test_maximize_window_not_found(monkeypatch):
+    wt = importlib.import_module('modules.window_tools')
+    mock_gw = types.SimpleNamespace(getAllTitles=lambda: [], getActiveWindow=lambda: None)
+    monkeypatch.setattr(wt, 'gw', mock_gw)
+    monkeypatch.setattr(wt, '_IMPORT_ERROR', None)
+    monkeypatch.setattr(wt, '_PYAUTOGUI_ERROR', None)
+    monkeypatch.setattr(wt, 'pyautogui', types.SimpleNamespace(hotkey=lambda *a: None, press=lambda *a: None))
+
+    ok, msg = wt.maximize_window('nothing')
+    assert not ok
+    assert 'no window found' in msg.lower()
+
+
+def test_maximize_window_success(monkeypatch):
+    wt = importlib.import_module('modules.window_tools')
+
+    class MockWin:
+        def __init__(self, title):
+            self.title = title
+            self.maxed = False
+        def activate(self):
+            pass
+        def maximize(self):
+            self.maxed = True
+
+    mock_win = MockWin('Chrome')
+    mock_gw = types.SimpleNamespace(
+        getAllTitles=lambda: ['Chrome'],
+        getWindowsWithTitle=lambda t: [mock_win],
+        getActiveWindow=lambda: mock_win,
+    )
+    monkeypatch.setattr(wt, 'gw', mock_gw)
+    monkeypatch.setattr(wt, '_IMPORT_ERROR', None)
+    monkeypatch.setattr(wt, '_PYAUTOGUI_ERROR', None)
+    monkeypatch.setattr(wt, 'pyautogui', types.SimpleNamespace(hotkey=lambda *a: None, press=lambda *a: None))
+
+    ok, msg = wt.maximize_window('chrome')
+    assert ok
+    assert mock_win.maxed
+    assert 'chrome' in msg.lower()


### PR DESCRIPTION
## Summary
- support maximizing windows with a new `maximize_window` function
- add Alt+Tab fallback to `focus_window`
- expose maximize capability through orchestrator alias and README docs
- test new functionality

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68842edfb7c483249eb5ddd6582fd1ac