### PR TITLE
Update Module Generator to use ChatGPT

### DIFF
--- a/tests/test_codex_integration.py
+++ b/tests/test_codex_integration.py
@@ -13,7 +13,7 @@ def mock_post(url, json=None, headers=None, timeout=60):
             pass
 
         def json(self):
-            return {"choices": [{"text": "def demo():\n    return True"}]}
+            return {"choices": [{"message": {"content": "def demo():\n    return True"}}]}
 
     return Dummy()
 


### PR DESCRIPTION
## Summary
- switch CodexClient to ChatGPT-based endpoint
- adjust tests for new ChatGPT response schema

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688431c5cd588324bb54cb3a443f1dcc