### PR TITLE
Enable natural language window management

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Focus windows by title with Alt+Tab/Cmd+Tab fallback (e.g. "focus Spotify")**
 - **Type text into any window by title (e.g. "type hello in Notepad")**
 - **Unified window manager module:** open, close, resize and automate known apps with stored workflows
+- **Natural language window control:** commands like `open Notepad`, `close Chrome`, or `resize Spotify to 800x600`
 - **Control music playback with media keys (play/pause, skip) using keyboard, Windows API, or pyautogui fallbacks**
 - **Control Xbox Game Bar capture:** open the overlay, start/stop recording, take screenshots, or capture the last 30 seconds
 - **Automatic multi-command parsing:** say "play music and open Rocket League" to run tasks one after another

--- a/cli_assistant.py
+++ b/cli_assistant.py
@@ -233,7 +233,9 @@ def handle_cli_input(user_input: str) -> str | None:
 
 def cli_loop():
     print(
-        "Local AI Assistant with Memory\nType 'exit' to quit, 'recall <keyword>' to search memory."
+        "Local AI Assistant with Memory\n"
+        "Type 'exit' to quit, 'recall <keyword>' to search memory.\n"
+        "Try window commands like 'open notepad', 'close chrome window', or 'resize spotify to 800 600'."
     )
     while True:
         user_input = input("You: ")

--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -1135,7 +1135,7 @@ if pystray is not None:
 
 # ========== WELCOME MESSAGE ==========
 output.insert(tk.END, "Assistant: Welcome to your local AI assistant! Speak or type your prompt.\n")
-output.insert(tk.END, "Assistant: Try: capture region 100 200 300 300  | click image red_button.png\n\n")
+output.insert(tk.END, "Assistant: Try: 'open notepad', 'close chrome window', or 'resize spotify to 800 600'.\n")
 
 # ========= Watcher Thread ========
 def start_config_watcher():

--- a/tests/test_open_close_resize_alias.py
+++ b/tests/test_open_close_resize_alias.py
@@ -1,0 +1,82 @@
+import importlib
+import types
+import sys
+
+
+def test_open_alias(monkeypatch):
+    awm = types.ModuleType('modules.app_window_manager')
+    called = {}
+
+    def mock_open(app):
+        called['app'] = app
+        return True, f"opened {app}"
+
+    awm.open_application = mock_open
+    awm.__all__ = ['open_application']
+    monkeypatch.setitem(sys.modules, 'modules.app_window_manager', awm)
+
+    stub_assistant = types.ModuleType('assistant')
+    stub_assistant.talk_to_llm = lambda t: 'ignored'
+    monkeypatch.setitem(sys.modules, 'assistant', stub_assistant)
+
+    orch = importlib.reload(importlib.import_module('orchestrator'))
+
+    result = orch.parse_and_execute('open notepad')
+    assert result == 'opened notepad'
+    assert called['app'] == 'notepad'
+
+
+def test_close_alias(monkeypatch):
+    awm = types.ModuleType('modules.app_window_manager')
+    called = {}
+
+    def mock_close(title):
+        called['title'] = title
+        return True, f"closed {title}"
+
+    awm.close_window = mock_close
+    awm.__all__ = ['close_window']
+    monkeypatch.setitem(sys.modules, 'modules.app_window_manager', awm)
+
+    stub_assistant = types.ModuleType('assistant')
+    stub_assistant.talk_to_llm = lambda t: 'ignored'
+    monkeypatch.setitem(sys.modules, 'assistant', stub_assistant)
+
+    orch = importlib.reload(importlib.import_module('orchestrator'))
+
+    result = orch.parse_and_execute('close chrome window')
+    assert result == 'closed chrome'
+    assert called['title'] == 'chrome'
+
+
+def test_resize_alias(monkeypatch):
+    import modules.app_window_manager as awm
+    import modules.automation_actions as aa
+    args = {}
+
+    def mock_resize(title, w, h):
+        args['title'] = title
+        args['w'] = w
+        args['h'] = h
+        return f"resized {title} to {w}x{h}"
+
+    monkeypatch.setattr(awm, 'resize_window', mock_resize)
+    monkeypatch.setattr(aa, 'resize_window', mock_resize)
+    awm.__all__ = ['resize_window']
+    aa.__all__ = ['resize_window']
+    monkeypatch.setitem(sys.modules, 'modules.app_window_manager', awm)
+    monkeypatch.setitem(sys.modules, 'modules.automation_actions', aa)
+
+    stub_assistant = types.ModuleType('assistant')
+    stub_assistant.talk_to_llm = lambda t: 'ignored'
+    monkeypatch.setitem(sys.modules, 'assistant', stub_assistant)
+
+    orch = importlib.reload(importlib.import_module('orchestrator'))
+    orch.TOOLS.resize_window = mock_resize
+    orch._rebuild_allowed()
+
+    result = orch.parse_and_execute('resize notepad to 800 600')
+    assert result == 'resized notepad to 800x600'
+    assert args['title'] == 'notepad'
+    assert args['w'] == 800
+    assert args['h'] == 600


### PR DESCRIPTION
## Summary
- expose natural language window management commands
- update CLI and GUI welcome text
- document new commands in README
- add tests for open/close/resize window aliases

## Testing
- `ruff check orchestrator.py cli_assistant.py gui_assistant.py tests/test_open_close_resize_alias.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688446585b7c8324bfc677a639523f44