### PR TITLE
Add local Stable Diffusion CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,17 @@ pip install openai python-dotenv
 python examples/openai_chat_example.py
 ```
 
+### Local Stable Diffusion Example
+Use the CLI script in `examples/stable_diffusion_example.py` to generate an image
+with your local model:
+
+```bash
+pip install diffusers huggingface-hub torch Pillow
+python examples/stable_diffusion_example.py --prompt "A sunset over the hills" --model /path/to/model
+```
+The script saves images under `generated_images/` and opens a preview window if
+Pillow is available.
+
 ### Allowed Plugin APIs
 The `ModuleRegistry` can optionally verify imports when loading modules. If this
 feature is enabled, any module that tries to import a banned package will fail

--- a/examples/stable_diffusion_example.py
+++ b/examples/stable_diffusion_example.py
@@ -1,0 +1,62 @@
+"""Example CLI for local Stable Diffusion image generation."""
+from __future__ import annotations
+
+import argparse
+import os
+import webbrowser
+
+import importlib
+
+try:
+    from PIL import Image  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Image = None  # type: ignore
+
+
+def preview_image(path: str) -> None:
+    """Open the generated image using Pillow or the default viewer."""
+    if Image is not None:
+        try:
+            img = Image.open(path)
+            img.show()
+            return
+        except Exception:
+            pass
+    webbrowser.open(f"file://{os.path.abspath(path)}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Generate an image from ``argv`` options and show a preview."""
+    parser = argparse.ArgumentParser(
+        description="Generate a local image using Stable Diffusion"
+    )
+    parser.add_argument("--prompt", required=True, help="Text prompt for the image")
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Path to the Stable Diffusion model checkpoint",
+    )
+    parser.add_argument(
+        "--device",
+        default=None,
+        help="Torch device string (default selects the best device)",
+    )
+    parser.add_argument(
+        "--no-preview",
+        action="store_true",
+        help="Skip showing the image after generation",
+    )
+    args = parser.parse_args(argv)
+
+    sd_generator = importlib.import_module("modules.stable_diffusion_generator")
+    path = sd_generator.generate_image(args.prompt, args.model, device=args.device)
+    if path.endswith(".png") and os.path.exists(path):
+        print(f"Image saved to {path}")
+        if not args.no_preview:
+            preview_image(path)
+    else:
+        print(path)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    main()

--- a/tests/test_stable_diffusion_example.py
+++ b/tests/test_stable_diffusion_example.py
@@ -1,0 +1,73 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+MODULE_PATH = "examples.stable_diffusion_example"
+
+
+def reload_module(monkeypatch):
+    if MODULE_PATH in sys.modules:
+        del sys.modules[MODULE_PATH]
+    return importlib.import_module(MODULE_PATH)
+
+
+def test_preview_image_with_pillow(monkeypatch, tmp_path):
+    mod = reload_module(monkeypatch)
+    path = tmp_path / "img.png"
+    path.write_text("img")
+
+    class DummyImg:
+        def show(self):
+            DummyImg.shown = True
+
+    class DummyPIL:
+        @staticmethod
+        def open(p):
+            assert p == str(path)
+            return DummyImg()
+
+    monkeypatch.setattr(mod, "Image", DummyPIL)
+    web_calls = []
+    monkeypatch.setattr(mod.webbrowser, "open", lambda u: web_calls.append(u))
+
+    mod.preview_image(str(path))
+    assert getattr(DummyImg, "shown", False)
+    assert not web_calls
+
+
+def test_preview_image_fallback(monkeypatch, tmp_path):
+    mod = reload_module(monkeypatch)
+    path = tmp_path / "img.png"
+    path.write_text("img")
+
+    monkeypatch.setattr(mod, "Image", None)
+    urls = []
+    monkeypatch.setattr(mod.webbrowser, "open", lambda u: urls.append(u))
+
+    mod.preview_image(str(path))
+    assert urls and urls[0].startswith("file://")
+
+
+def test_main(monkeypatch, tmp_path, capsys):
+    def mock_generate_image(prompt, model, device=None):
+        file_path = tmp_path / "out.png"
+        file_path.write_text("fake")
+        return str(file_path)
+
+    sd_mod = types.SimpleNamespace(generate_image=mock_generate_image)
+    monkeypatch.setitem(sys.modules, "modules.stable_diffusion_generator", sd_mod)
+    mod = reload_module(monkeypatch)
+
+    monkeypatch.setattr(mod, "preview_image", lambda p: None)
+
+    mod.main([
+        "--prompt",
+        "hello",
+        "--model",
+        "path",
+        "--device",
+        "cpu",
+    ])
+    out = capsys.readouterr().out
+    assert "Image saved to" in out


### PR DESCRIPTION
## Summary
- add `examples/stable_diffusion_example.py` for easy local generation
- preview generated images via Pillow or default viewer
- expose `generate_image_url` in `image_generator` and handle missing deps
- extend orchestrator with basic window command aliases
- document Stable Diffusion example in README
- tests for new example and aliases

## Testing
- `flake8`
- `pytest tests/test_image_generator_url.py tests/test_open_close_resize_alias.py tests/test_maximize_alias.py tests/test_stable_diffusion_example.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68845bde5040832484698eb04966d377