### PR TITLE
Add imagine_generator module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Hotkeys tab with a macro recorder and 3-second countdown**
 - **Vision/ocr tools:** Screen capture and image recognition by voice or command
 - **Local image generation via Stable Diffusion (no cloud required; requires `diffusers` and `torch`)**
+- **Cloud image generation via the Imagine API or DALL-E**
 - **Home Assistant integration via REST API (disabled by default)**
 - **Plugin system:** Easy extension with your own Python modules
 - **Interactive module generator with preview and confirmation**

--- a/modules/imagine_generator.py
+++ b/modules/imagine_generator.py
@@ -1,0 +1,63 @@
+"""Unified interface for cloud and local image generation."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from . import image_generator as ig
+from . import stable_diffusion_generator as sd
+
+MODULE_NAME = "imagine_generator"
+
+__all__ = ["imagine", "get_info", "get_description"]
+
+
+def imagine(
+    prompt: str,
+    *,
+    source: str = "cloud",
+    model: str = "dall-e-3",
+    size: str = "512x512",
+    save_dir: str = "generated_images",
+    sd_model_path: str | None = None,
+    device: str | None = None,
+) -> str:
+    """Generate an image using the specified backend.
+
+    Parameters
+    ----------
+    prompt:
+        Text description of the desired image.
+    source:
+        ``"cloud"`` uses :mod:`modules.image_generator`.
+        ``"local"`` uses :mod:`modules.stable_diffusion_generator`.
+    model:
+        Model identifier for the cloud provider.
+    size:
+        Image resolution for the cloud provider.
+    save_dir:
+        Directory to store the generated image.
+    sd_model_path:
+        Path to the Stable Diffusion model when ``source`` is ``"local"``.
+    device:
+        Torch device string for local generation.
+    """
+    if source == "local":
+        if not sd_model_path:
+            return "Stable Diffusion model path required"
+        return sd.generate_image(prompt, sd_model_path, device=device, save_dir=save_dir)
+    return ig.generate_image(prompt, model=model, size=size, save_dir=save_dir)
+
+
+def get_info() -> dict:
+    """Return module metadata for discovery."""
+    return {
+        "name": MODULE_NAME,
+        "description": get_description(),
+        "functions": ["imagine"],
+    }
+
+
+def get_description() -> str:
+    """Return a short description of this module."""
+    return "Generate images via cloud APIs or local Stable Diffusion."

--- a/tests/test_imagine_generator.py
+++ b/tests/test_imagine_generator.py
@@ -1,0 +1,35 @@
+import importlib
+
+import modules.imagine_generator as im_gen
+
+
+def test_imagine_local(monkeypatch):
+    calls = {}
+
+    def mock_sd(prompt, path, *, device=None, save_dir="generated_images"):
+        calls["sd"] = (prompt, path, device, save_dir)
+        return "sd.png"
+
+    monkeypatch.setattr(im_gen.sd, "generate_image", mock_sd)
+    out = im_gen.imagine("cat", source="local", sd_model_path="model", device="cpu")
+    assert out == "sd.png"
+    assert calls["sd"] == ("cat", "model", "cpu", "generated_images")
+
+
+def test_imagine_cloud(monkeypatch):
+    calls = {}
+
+    def mock_cloud(prompt, *, model="dall-e-3", size="512x512", save_dir="generated_images"):
+        calls["cloud"] = (prompt, model, size, save_dir)
+        return "cloud.png"
+
+    monkeypatch.setattr(im_gen.ig, "generate_image", mock_cloud)
+    out = im_gen.imagine(
+        "dog",
+        source="cloud",
+        model="dall-e-2",
+        size="256x256",
+        save_dir="imgs",
+    )
+    assert out == "cloud.png"
+    assert calls["cloud"] == ("dog", "dall-e-2", "256x256", "imgs")


### PR DESCRIPTION
## Summary
- add imagine_generator module to unify cloud and local image creation
- test imagine_generator logic
- document the new cloud image generation feature in README

## Testing
- `ruff check modules/imagine_generator.py tests/test_imagine_generator.py`
- `pytest -k imagine_generator -q`


------
https://chatgpt.com/codex/tasks/task_e_688462e2a68883249c77f444552af7a0