### PR TITLE
Add ETA preview for image generation

### DIFF
--- a/tests/test_image_eta.py
+++ b/tests/test_image_eta.py
@@ -1,0 +1,26 @@
+import importlib
+import os
+import sys
+import pytest
+
+
+def import_gui():
+    os.environ["PYTEST_CURRENT_TEST"] = "1"
+    if "gui_assistant" in sys.modules:
+        del sys.modules["gui_assistant"]
+    return importlib.import_module("gui_assistant")
+
+
+@pytest.mark.skipif(os.environ.get("DISPLAY") is None, reason="GUI not available")
+def test_eta_default(monkeypatch):
+    ga = import_gui()
+    assert ga.estimate_image_eta() == 10.0
+
+
+@pytest.mark.skipif(os.environ.get("DISPLAY") is None, reason="GUI not available")
+def test_eta_records(monkeypatch):
+    ga = import_gui()
+    ga._eta_history.clear()
+    ga.record_image_duration(5)
+    ga.record_image_duration(7)
+    assert abs(ga.estimate_image_eta() - 6.0) < 0.01


### PR DESCRIPTION
## Summary
- show ETA countdown in image generator tab
- use white canvas preview until image is ready
- record past generation durations for better estimates
- test ETA helper functions

## Testing
- `ruff check gui_assistant.py tests/test_image_eta.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688478ba53fc8324806572ca16ab71a1