### PR TITLE
Add dependency update helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ pip install -r requirements.txt
 # Or run the cross‑platform helper:
 python install_requirements.py
 # Windows: run install_requirements.bat for a quick install
+python update_dependencies.py
+# Windows: run update_dependencies.bat to sync new modules
 # or run setup_venv.py (Windows: setup_venv.bat) to create the `venv/` folder
 # and install everything automatically
 # Optional: fetch local LLM backends (LocalAI, text-generation-webui, Ollama)
@@ -440,6 +442,7 @@ We welcome contributions to make the Local Modular AI Assistant even better! Her
 - Create a new Python file in the `modules/` directory.
 - Use the module template in `examples/my_module.py` (or see `generate_module.py`) for reference.
 - Be sure to include a `get_info()` function for discovery and testing.
+- List additional packages in a REQUIREMENTS = ["pkg"] variable so `update_dependencies.py` can install them.
  - Add your module to your local project and test it with `examples/test_full_run.py`.
 - (Optional) Add a test script in `/tests`.
 

--- a/tests/test_update_dependencies.py
+++ b/tests/test_update_dependencies.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import tempfile
+import textwrap
+
+from update_dependencies import collect_module_requirements, read_requirements_file, write_requirements_file
+
+
+def test_collect_module_requirements(tmp_path: Path) -> None:
+    mod_dir = tmp_path / "modules"
+    mod_dir.mkdir()
+    (mod_dir / "sample.py").write_text('REQUIREMENTS = ["foo", "bar"]\n')
+    reqs = collect_module_requirements(mod_dir)
+    assert reqs == {"foo", "bar"}
+
+
+def test_write_and_read(tmp_path: Path) -> None:
+    req_file = tmp_path / "req.txt"
+    write_requirements_file(req_file, ["a", "b"])
+    result = read_requirements_file(req_file)
+    assert result == ["a", "b"]

--- a/update_dependencies.bat
+++ b/update_dependencies.bat
@@ -1,0 +1,5 @@
+@echo off
+REM Update requirements.txt based on module REQUIREMENTS and install them
+cd /d "%~dp0"
+python update_dependencies.py
+pause

--- a/update_dependencies.py
+++ b/update_dependencies.py
@@ -1,0 +1,80 @@
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+MODULES_DIR = Path(__file__).parent / "modules"
+REQUIREMENTS_FILE = Path(__file__).parent / "requirements.txt"
+
+
+def parse_requirements(path: Path) -> list[str]:
+    """Return REQUIREMENTS list from a module file."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except Exception:
+        return []
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "REQUIREMENTS":
+                    if isinstance(node.value, (ast.List, ast.Tuple)):
+                        items = []
+                        for elt in node.value.elts:
+                            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                                items.append(elt.value)
+                        return items
+    return []
+
+
+def collect_module_requirements(mod_dir: Path) -> set[str]:
+    """Collect all REQUIREMENTS from modules in ``mod_dir``."""
+    reqs: set[str] = set()
+    for file in mod_dir.glob("*.py"):
+        reqs.update(parse_requirements(file))
+    return reqs
+
+
+def read_requirements_file(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    lines = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                lines.append(line)
+    return lines
+
+
+def write_requirements_file(path: Path, reqs: list[str]) -> None:
+    tmp = path.with_suffix(".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        for dep in reqs:
+            f.write(dep + "\n")
+    tmp.replace(path)
+
+
+def install_new_packages(packages: list[str]) -> None:
+    if not packages:
+        return
+    cmd = [sys.executable, "-m", "pip", "install", *packages]
+    print("Installing:", " ".join(packages))
+    subprocess.check_call(cmd)
+
+
+def main() -> None:
+    module_reqs = collect_module_requirements(MODULES_DIR)
+    existing = read_requirements_file(REQUIREMENTS_FILE)
+    missing = sorted(module_reqs - set(existing))
+
+    if missing:
+        print("Adding new dependencies:", ", ".join(missing))
+        all_reqs = existing + missing
+        write_requirements_file(REQUIREMENTS_FILE, all_reqs)
+        install_new_packages(missing)
+    else:
+        print("No new dependencies found.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `update_dependencies.py` utility to scan modules for `REQUIREMENTS` lists and install missing packages
- provide Windows batch wrapper
- document automatic dependency update process in README
- note `REQUIREMENTS` variable for new modules
- add tests for update dependency helper

## Testing
- `flake8`
- `pytest tests/test_update_dependencies.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68847a0c9f888324aab00b3f3adeaa14