### PR TITLE
Add saved SD model paths to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Hotkeys tab with a macro recorder and 3-second countdown**
 - **Vision/ocr tools:** Screen capture and image recognition by voice or command
 - **Local image generation via Stable Diffusion (no cloud required; requires `diffusers` and `torch`)**
+- **Save and switch between multiple Stable Diffusion model paths**
 - **Cloud image generation via the Imagine API or DALL-E**
 - **Home Assistant integration via REST API (disabled by default)**
 - **Plugin system:** Easy extension with your own Python modules

--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -63,6 +63,7 @@ from modules import api_keys
 from modules import debug_panel
 from modules import image_generator
 from modules import stable_diffusion_generator as sd_generator
+from modules import sd_model_manager
 from modules.browser_automation import set_webview_callback
 from modules import web_activity
 try:
@@ -813,6 +814,48 @@ sd_model_var = tk.StringVar(value="")
 ttk.Label(image_tab, text="SD Model Path:").pack(anchor="w", padx=10, pady=(5, 0))
 sd_model_entry = ttk.Entry(image_tab, textvariable=sd_model_var, width=50)
 sd_model_entry.pack(fill="x", padx=10)
+
+saved_sd_models = sd_model_manager.load_models()
+sd_model_list = tk.Listbox(image_tab, height=3)
+for _m in saved_sd_models:
+    sd_model_list.insert(tk.END, _m)
+sd_model_list.pack(fill="x", padx=10, pady=(5, 0))
+
+
+def select_sd_model(_event=None) -> None:
+    if sd_model_list.curselection():
+        sd_model_var.set(sd_model_list.get(sd_model_list.curselection()[0]))
+
+
+def add_sd_model() -> None:
+    path = sd_model_var.get().strip()
+    if not path:
+        img_status.config(text="Enter a model path first.")
+        return
+    if path not in saved_sd_models:
+        saved_sd_models.append(path)
+        sd_model_manager.save_models(saved_sd_models)
+        sd_model_list.insert(tk.END, path)
+        img_status.config(text=f"Saved {path}")
+    else:
+        img_status.config(text="Model already saved.")
+
+
+def remove_sd_model() -> None:
+    if not sd_model_list.curselection():
+        img_status.config(text="Select a model to remove.")
+        return
+    idx = sd_model_list.curselection()[0]
+    path = saved_sd_models.pop(idx)
+    sd_model_list.delete(idx)
+    sd_model_manager.save_models(saved_sd_models)
+    img_status.config(text=f"Removed {path}")
+
+sd_model_list.bind("<Double-Button-1>", select_sd_model)
+btn_sd = ttk.Frame(image_tab)
+btn_sd.pack(pady=(0, 5))
+ttk.Button(btn_sd, text="Save Model Path", command=add_sd_model).pack(side=tk.LEFT, padx=5)
+ttk.Button(btn_sd, text="Remove Selected", command=remove_sd_model).pack(side=tk.LEFT, padx=5)
 
 sd_device_var = tk.StringVar(value=gpu.get_device())
 ttk.Label(image_tab, text="Device:").pack(anchor="w", padx=10, pady=(5, 0))

--- a/modules/sd_model_manager.py
+++ b/modules/sd_model_manager.py
@@ -1,0 +1,88 @@
+"""Manage saved Stable Diffusion model paths."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List
+
+from modules.utils import resource_path
+
+MODULE_NAME = "sd_model_manager"
+MODELS_FILE = resource_path("sd_models.json")
+
+model_paths: List[str] = []
+
+__all__ = [
+    "load_models",
+    "save_models",
+    "add_model",
+    "remove_model",
+    "get_info",
+    "get_description",
+]
+
+
+def load_models() -> List[str]:
+    """Load saved model paths from :data:`MODELS_FILE`."""
+    global model_paths
+    try:
+        with open(MODELS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            model_paths = [str(p) for p in data if isinstance(p, str)]
+        else:
+            model_paths = []
+    except Exception:
+        model_paths = []
+    return model_paths
+
+
+def save_models(models: List[str] | None = None) -> None:
+    """Persist ``models`` to :data:`MODELS_FILE`."""
+    if models is None:
+        models = model_paths
+    with open(MODELS_FILE, "w", encoding="utf-8") as f:
+        json.dump(models, f, indent=2)
+
+
+def add_model(path: str) -> None:
+    """Add ``path`` to :data:`model_paths` and save."""
+    if not path:
+        return
+    if path not in model_paths:
+        model_paths.append(path)
+        save_models()
+
+
+def remove_model(path: str) -> bool:
+    """Remove ``path`` from :data:`model_paths` if present."""
+    try:
+        model_paths.remove(path)
+        save_models()
+        return True
+    except ValueError:
+        return False
+
+
+def get_info() -> dict:
+    """Return module metadata for discovery."""
+    return {
+        "name": MODULE_NAME,
+        "description": get_description(),
+        "functions": [
+            "load_models",
+            "save_models",
+            "add_model",
+            "remove_model",
+        ],
+    }
+
+
+def get_description() -> str:
+    """Return a short description of this module."""
+    return "Manage saved Stable Diffusion model paths."
+
+
+# Initialize on import
+load_models()

--- a/tests/test_sd_model_manager.py
+++ b/tests/test_sd_model_manager.py
@@ -1,0 +1,33 @@
+import importlib
+import json
+
+
+def test_add_and_remove_models(tmp_path, monkeypatch):
+    mod = importlib.import_module('modules.sd_model_manager')
+    importlib.reload(mod)
+    models_file = tmp_path / 'models.json'
+    monkeypatch.setattr(mod, 'MODELS_FILE', str(models_file), raising=False)
+    mod.model_paths = []
+    mod.save_models([])
+
+    mod.add_model('one')
+    mod.add_model('two')
+    assert mod.model_paths == ['one', 'two']
+
+    removed = mod.remove_model('one')
+    assert removed is True
+    assert mod.model_paths == ['two']
+    saved = json.loads(models_file.read_text())
+    assert saved == ['two']
+
+
+def test_load_models_corruption(tmp_path, monkeypatch):
+    mod = importlib.import_module('modules.sd_model_manager')
+    importlib.reload(mod)
+    models_file = tmp_path / 'models.json'
+    models_file.write_text('{bad')
+    monkeypatch.setattr(mod, 'MODELS_FILE', str(models_file), raising=False)
+    mod.model_paths = ['x']
+    models = mod.load_models()
+    assert models == []
+    assert mod.model_paths == []


### PR DESCRIPTION
## Summary
- add `sd_model_manager` module to track saved Stable Diffusion models
- expose Save/Remove SD model path controls in the Image Generator tab
- allow selecting saved models and persist to `sd_models.json`
- document feature in README
- add unit tests for new manager module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68847a600bcc832498c819600291b006