### PR TITLE
Implement console hiding for GUI startup

### DIFF
--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -80,7 +80,7 @@ from modules.tts_integration import is_speaking
 import modules.tts_integration as tts_module
 from modules import speech_learning
 # utils is located within the modules package
-from modules.utils import resource_path, project_path
+from modules.utils import resource_path, project_path, hide_cmd_window
 from modules import wake_sleep_hotkey
 from modules import api_keys
 from modules import debug_panel
@@ -127,6 +127,7 @@ else:
     root.title("AI Assistant")
     # Default size increased so all controls fit comfortably
     root.geometry("900x650")
+    hide_cmd_window()
 
 # Notebook with main UI and speech training tab
 notebook = ttk.Notebook(root)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -5,7 +5,13 @@ import sys
 import re
 from pathlib import Path
 
-__all__ = ["resource_path", "project_path", "chunk_text", "clean_for_tts"]
+__all__ = [
+    "resource_path",
+    "project_path",
+    "chunk_text",
+    "clean_for_tts",
+    "hide_cmd_window",
+]
 
 def resource_path(relative_path: str) -> str:
     """Return absolute path for ``relative_path`` inside packaged app."""
@@ -58,6 +64,7 @@ def get_info():
             "project_path",
             "chunk_text",
             "clean_for_tts",
+            "hide_cmd_window",
         ]
     }
 
@@ -65,3 +72,16 @@ def get_info():
 def get_description() -> str:
     """Return a short summary of this module."""
     return "General helper utilities for file paths and text cleaning."
+
+
+def hide_cmd_window() -> None:
+    """Hide the console window on Windows, if present."""
+    if sys.platform != "win32":
+        return
+    try:  # pragma: no cover - Windows only
+        import ctypes
+        hwnd = ctypes.windll.kernel32.GetConsoleWindow()
+        if hwnd:
+            ctypes.windll.user32.ShowWindow(hwnd, 0)
+    except Exception as exc:  # pragma: no cover - optional failure
+        print(f"[utils] Could not hide console: {exc}")

--- a/tests/test_hide_cmd_window.py
+++ b/tests/test_hide_cmd_window.py
@@ -1,0 +1,7 @@
+import importlib
+
+
+def test_hide_cmd_window_non_windows():
+    """Ensure hiding the console does not raise on non-Windows systems."""
+    utils = importlib.import_module("modules.utils")
+    utils.hide_cmd_window()


### PR DESCRIPTION
## Summary
- allow hiding the launching console on Windows
- expose `hide_cmd_window` via `modules.utils`
- invoke console hiding from `gui_assistant`
- ensure functionality is tested

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885075a101c8324901ca192fe466d21