### PR TITLE
Enable live GUI image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Local image generation via Stable Diffusion (no cloud required; requires `diffusers` and `torch`)**
 - **Save and switch between multiple Stable Diffusion model paths**
 - **Cloud image generation via the Imagine API or DALL-E**
+- **Image requests automatically open the GUI image tab with live progress**
 - **Home Assistant integration via REST API (disabled by default)**
 - **Plugin system:** Easy extension with your own Python modules
 - **Interactive module generator with preview and confirmation**

--- a/assistant.py
+++ b/assistant.py
@@ -411,7 +411,11 @@ def process_input(user_input, output_widget):
                 speak(msg)
                 last_ai_response = msg
                 return
-            if "increase speech volume" in text.lower() or "speech volume up" in text.lower() or "increase volume" in text.lower():
+            if (
+                "increase speech volume" in text.lower()
+                or "speech volume up" in text.lower()
+                or "increase volume" in text.lower()
+            ):
                 from modules import tts_integration
 
                 val = min(tts_integration.config.get("tts_volume", 0.8) + 0.1, 1.0)

--- a/tests/test_gui_image_generator.py
+++ b/tests/test_gui_image_generator.py
@@ -45,8 +45,16 @@ def run_generate_image(img_prompt, img_status, source_var, sd_model_var, sd_devi
 
 def test_generate_image_local(monkeypatch):
     calls = {}
-    monkeypatch.setattr(sd_gen, "generate_image", lambda *a, **k: calls.setdefault("sd", []).append((a, k)) or "sd.png")
-    monkeypatch.setattr(image_gen, "generate_image", lambda *a, **k: calls.setdefault("ig", []).append((a, k)) or "ig.png")
+    def log_sd(*a, **k):
+        calls.setdefault("sd", []).append((a, k))
+        return "sd.png"
+
+    def log_ig(*a, **k):
+        calls.setdefault("ig", []).append((a, k))
+        return "ig.png"
+
+    monkeypatch.setattr(sd_gen, "generate_image", log_sd)
+    monkeypatch.setattr(image_gen, "generate_image", log_ig)
 
     vars = dict(
         img_prompt=DummyText("cat"),
@@ -70,8 +78,16 @@ def test_generate_image_local(monkeypatch):
 
 def test_generate_image_cloud(monkeypatch):
     calls = {}
-    monkeypatch.setattr(sd_gen, "generate_image", lambda *a, **k: calls.setdefault("sd", []).append((a, k)) or "sd.png")
-    monkeypatch.setattr(image_gen, "generate_image", lambda *a, **k: calls.setdefault("ig", []).append((a, k)) or "ig.png")
+    def log_sd(*a, **k):
+        calls.setdefault("sd", []).append((a, k))
+        return "sd.png"
+
+    def log_ig(*a, **k):
+        calls.setdefault("ig", []).append((a, k))
+        return "ig.png"
+
+    monkeypatch.setattr(sd_gen, "generate_image", log_sd)
+    monkeypatch.setattr(image_gen, "generate_image", log_ig)
 
     vars = dict(
         img_prompt=DummyText("dog"),

--- a/tests/test_imagine_generator.py
+++ b/tests/test_imagine_generator.py
@@ -34,3 +34,19 @@ def test_imagine_cloud(monkeypatch):
     )
     assert out == "cloud.png"
     assert calls["cloud"] == ("dog", "dall-e-2", "256x256", "imgs", "foo")
+
+
+def test_imagine_gui_callback(monkeypatch):
+    calls = {}
+
+    def gui_cb(prompt, **kwargs):
+        calls["prompt"] = prompt
+        calls.update(kwargs)
+        return "gui.png"
+
+    im_gen.set_gui_callback(gui_cb)
+    monkeypatch.setattr(im_gen, "ig", importlib.import_module("modules.image_generator"))
+    out = im_gen.imagine("frog")
+    im_gen.set_gui_callback(None)
+    assert out == "gui.png"
+    assert calls["prompt"] == "frog"


### PR DESCRIPTION
## Summary
- register callback in `imagine_generator` for GUI integration
- implement `imagine_via_gui` in `gui_assistant` and wire up callback
- update tests for new callback and fix lint
- document new GUI behavior in README
- ensure video generation gracefully handles missing Pillow

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688506513fe483249050e811ca7bd39a