### PR TITLE
Add GUI console toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Memory viewer/editor:** adjust stored history and `memory_max` from the GUI
 - **Config editor tab:** tweak and save `config.json` without leaving the app
 - **Settings tab:** quickly switch between local and remote LLM servers
+- **Toggle console visibility on Windows from the Settings tab**
 - **Automatic .exe scanning builds a registry of installed applications**
 - **Download game launchers like Epic Games**
 - **Startup system/device/network scans populate registries and can be refreshed by voice**
@@ -167,6 +168,7 @@ Sample config.json:
   "resume_phrases": ["next question", "next answer"],
 
   "mic_overlay": true,
+  "hide_cmd_window": true,
   "mic_overlay_colors": {
     "listening": "green",
     "sleeping": "red",

--- a/config.json
+++ b/config.json
@@ -33,6 +33,7 @@
     "next answer"
   ],
   "mic_overlay": true,
+  "hide_cmd_window": true,
   "mic_overlay_colors": {
     "listening": "green",
     "sleeping": "red",

--- a/config_validator.py
+++ b/config_validator.py
@@ -32,6 +32,7 @@ CONFIG_SCHEMA = {
         "cancel_phrases": {"type": "array", "items": {"type": "string"}},
         "resume_phrases": {"type": "array", "items": {"type": "string"}},
         "mic_overlay": {"type": "boolean"},
+        "hide_cmd_window": {"type": "boolean"},
         "mic_overlay_colors": {
             "type": "object",
             "properties": {

--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -85,7 +85,7 @@ from modules.tts_integration import is_speaking
 import modules.tts_integration as tts_module
 from modules import speech_learning
 # utils is located within the modules package
-from modules.utils import resource_path, project_path, hide_cmd_window
+from modules.utils import resource_path, project_path, hide_cmd_window, show_cmd_window
 from modules import wake_sleep_hotkey
 from modules import api_keys
 from modules import debug_panel
@@ -134,7 +134,8 @@ else:
     root.title("AI Assistant")
     # Default size increased so all controls fit comfortably
     root.geometry("900x650")
-    hide_cmd_window()
+    if config.get("hide_cmd_window", True):
+        hide_cmd_window()
 
 # Notebook with main UI and speech training tab
 notebook = ttk.Notebook(root)
@@ -1381,6 +1382,7 @@ set_webview_callback(_load_url)
 # ---------- Settings Tab ----------
 use_remote_var = tk.BooleanVar(value=bool(config.get("llm_url")))
 url_var = tk.StringVar(value=config.get("llm_url", "http://localhost:11434/v1/chat/completions"))
+hide_cmd_var = tk.BooleanVar(value=config.get("hide_cmd_window", True))
 
 def _toggle_remote() -> None:
     state = tk.NORMAL if use_remote_var.get() else tk.DISABLED
@@ -1392,6 +1394,12 @@ ttk.Checkbutton(
     variable=use_remote_var,
     command=_toggle_remote,
 ).pack(anchor="w", padx=10, pady=(10, 5))
+
+ttk.Checkbutton(
+    settings_tab,
+    text="Hide console window (Windows)",
+    variable=hide_cmd_var,
+).pack(anchor="w", padx=10, pady=5)
 
 ttk.Label(settings_tab, text="LLM URL:").pack(anchor="w", padx=10)
 url_entry = ttk.Entry(settings_tab, textvariable=url_var, width=50)
@@ -1405,10 +1413,15 @@ def save_settings() -> None:
         cfg["llm_url"] = url_var.get().strip()
     else:
         cfg.pop("llm_url", None)
+    cfg["hide_cmd_window"] = hide_cmd_var.get()
     with open("config.json", "w", encoding="utf-8") as f:
         json.dump(cfg, f, indent=2)
     config_loader.config = cfg
     output.insert(tk.END, "[SYSTEM] Settings saved.\n")
+    if hide_cmd_var.get():
+        hide_cmd_window()
+    else:
+        show_cmd_window()
     reload_config()
 
 ttk.Button(settings_tab, text="Save Settings", command=save_settings).pack(pady=10)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -11,6 +11,7 @@ __all__ = [
     "chunk_text",
     "clean_for_tts",
     "hide_cmd_window",
+    "show_cmd_window",
 ]
 
 def resource_path(relative_path: str) -> str:
@@ -65,6 +66,7 @@ def get_info():
             "chunk_text",
             "clean_for_tts",
             "hide_cmd_window",
+            "show_cmd_window",
         ]
     }
 
@@ -85,3 +87,16 @@ def hide_cmd_window() -> None:
             ctypes.windll.user32.ShowWindow(hwnd, 0)
     except Exception as exc:  # pragma: no cover - optional failure
         print(f"[utils] Could not hide console: {exc}")
+
+
+def show_cmd_window() -> None:
+    """Show the console window on Windows, if present."""
+    if sys.platform != "win32":
+        return
+    try:  # pragma: no cover - Windows only
+        import ctypes
+        hwnd = ctypes.windll.kernel32.GetConsoleWindow()
+        if hwnd:
+            ctypes.windll.user32.ShowWindow(hwnd, 1)
+    except Exception as exc:  # pragma: no cover - optional failure
+        print(f"[utils] Could not show console: {exc}")

--- a/tests/test_settings_cmd_toggle.py
+++ b/tests/test_settings_cmd_toggle.py
@@ -1,0 +1,24 @@
+import importlib
+import json
+import os
+import sys
+import pytest
+
+
+@pytest.mark.skipif(os.environ.get("DISPLAY") is None, reason="GUI not available")
+def test_save_settings_writes_hide(monkeypatch, tmp_path):
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "1")
+    base = json.load(open("config.json", "r"))
+    base["hide_cmd_window"] = True
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(base))
+    from config_loader import ConfigLoader as CL
+    monkeypatch.setattr("config_loader.ConfigLoader", lambda path='config.json': CL(str(cfg_path)))
+    if "gui_assistant" in sys.modules:
+        del sys.modules["gui_assistant"]
+    ga = importlib.import_module("gui_assistant")
+    ga.hide_cmd_var.set(False)
+    ga.save_settings()
+    saved = json.loads(cfg_path.read_text())
+    assert saved["hide_cmd_window"] is False
+

--- a/tests/test_show_cmd_window.py
+++ b/tests/test_show_cmd_window.py
@@ -1,0 +1,7 @@
+import importlib
+
+
+def test_show_cmd_window_non_windows():
+    """Ensure showing the console does not raise on non-Windows systems."""
+    utils = importlib.import_module("modules.utils")
+    utils.show_cmd_window()


### PR DESCRIPTION
## Summary
- expose new setting `hide_cmd_window` in config and schema
- allow toggling console visibility from GUI settings
- implement `show_cmd_window` utility
- document feature and config option
- add tests for console toggle helpers

## Testing
- `pytest tests/test_show_cmd_window.py tests/test_settings_cmd_toggle.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688513775f608324b50039107a96a3f4