### PR TITLE
Add model path managers and GUI save options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Hotkeys tab with a macro recorder and 3-second countdown**
 - **Vision/ocr tools:** Screen capture and image recognition by voice or command
 - **Local image generation via Stable Diffusion (no cloud required; requires `diffusers` and `torch`)**
-- **Save and switch between multiple Stable Diffusion model paths**
+- **Save and switch between multiple Stable Diffusion, video, and 3D model paths**
 - **Cloud image generation via the Imagine API or DALL-E**
 - **Image requests automatically open the GUI image tab with live progress**
 - **Home Assistant integration via REST API (disabled by default)**

--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -39,6 +39,8 @@ def make_scrollable_frame(parent: tk.Widget) -> tk.Frame:
     canvas.pack(side="left", fill="both", expand=True)
     scrollbar.pack(side="right", fill="y")
     return frame
+
+
 try:
     from PIL import Image, ImageDraw, ImageTk  # type: ignore
 except Exception:  # Pillow is optional
@@ -54,6 +56,7 @@ import atexit
 from error_logger import log_error
 from modules import gpu
 import io
+
 try:
     import trimesh
 except Exception:  # pragma: no cover - optional dependency
@@ -61,6 +64,7 @@ except Exception:  # pragma: no cover - optional dependency
 try:
     from watchdog.observers import Observer
     from config_watcher import ConfigFileChangeHandler
+
     WATCHDOG_AVAILABLE = True
 except Exception:
     Observer = None  # type: ignore
@@ -79,11 +83,13 @@ from assistant import (
     set_listening,
     get_state,
 )
+
 # voice_input module lives inside the modules package
 from modules.voice_input import start_voice_listener
 from modules.tts_integration import is_speaking
 import modules.tts_integration as tts_module
 from modules import speech_learning
+
 # utils is located within the modules package
 from modules.utils import resource_path, project_path, hide_cmd_window
 from modules import wake_sleep_hotkey
@@ -95,8 +101,11 @@ from modules import imagine_generator
 from modules import video_generator
 from modules import stable_fast_3d as fast3d_generator
 from modules import sd_model_manager
+from modules import video_model_manager
+from modules import fast3d_model_manager
 from modules.browser_automation import set_webview_callback
 from modules import web_activity
+
 try:
     from tkinterweb import HtmlFrame  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
@@ -119,6 +128,7 @@ api_keys.apply_keys_from_config()
 
 # ========== TKINTER GUI SETUP ==========
 if os.environ.get("PYTEST_CURRENT_TEST"):
+
     class DummyTk:
         def __init__(self):
             self.tk = self
@@ -128,6 +138,7 @@ if os.environ.get("PYTEST_CURRENT_TEST"):
 
         def __getattr__(self, _name):
             return lambda *a, **k: None
+
     root = DummyTk()
 else:
     root = tk.Tk()
@@ -179,6 +190,7 @@ notebook.bind("<<NotebookTabChanged>>", _fit_window)
 config_text = tk.Text(config_tab, wrap=tk.WORD)
 config_text.pack(fill="both", expand=True, padx=10, pady=10)
 
+
 def load_config_text() -> None:
     """Load ``config.json`` into the editor widget."""
     try:
@@ -188,6 +200,7 @@ def load_config_text() -> None:
         data = f"Error loading config: {exc}\n"
     config_text.delete("1.0", tk.END)
     config_text.insert(tk.END, data)
+
 
 def save_config_text() -> None:
     """Validate and save the config editor contents."""
@@ -207,11 +220,16 @@ def save_config_text() -> None:
     output.insert(tk.END, "[SYSTEM] Config saved.\n")
     reload_config()
 
+
 btn_frame = ttk.Frame(config_tab)
 btn_frame.pack(pady=(0, 10))
-ttk.Button(btn_frame, text="Reload", command=load_config_text).pack(side=tk.LEFT, padx=5)
+ttk.Button(btn_frame, text="Reload", command=load_config_text).pack(
+    side=tk.LEFT, padx=5
+)
 ttk.Button(btn_frame, text="Save", command=save_config_text).pack(side=tk.LEFT)
-ttk.Button(btn_frame, text="Edit Memory", command=open_memory_window).pack(side=tk.LEFT, padx=5)
+ttk.Button(btn_frame, text="Edit Memory", command=open_memory_window).pack(
+    side=tk.LEFT, padx=5
+)
 
 load_config_text()
 # Apply a modern ttk theme if available
@@ -219,9 +237,11 @@ style = ttk.Style()
 if "clam" in style.theme_names():
     style.theme_use("clam")
 
+
 # Close button should minimize to tray
 def on_close():
     root.withdraw()
+
 
 root.protocol("WM_DELETE_WINDOW", on_close)
 
@@ -231,7 +251,9 @@ frame.pack(padx=10, pady=10, fill="both", expand=True)
 # Main output console (read-only for user)
 output = ReadOnlyText(frame, height=20, wrap=tk.WORD)
 output.pack(fill="both", expand=True)
-output.insert(tk.END, "Assistant: Assistant is sleeping. Say your wake phrase to activate.\n")
+output.insert(
+    tk.END, "Assistant: Assistant is sleeping. Say your wake phrase to activate.\n"
+)
 
 
 # Frame for command entry and action buttons
@@ -261,6 +283,7 @@ if errors:
     print("Config validation failed. Fix and restart the app.")
     sys.exit(1)
 
+
 # ========== MIC STATUS OVERLAY (UI ONLY) ==========
 def create_mic_icon(color):
     """Create a microphone status icon.
@@ -275,16 +298,20 @@ def create_mic_icon(color):
     draw.ellipse((5, 5, 35, 35), fill=color)
     return ImageTk.PhotoImage(img)
 
+
 mic_active_icon = create_mic_icon("green")
 mic_sleep_icon = create_mic_icon("red")
 mic_hardmute_icon = create_mic_icon("gray")
 
 mic_button = tk.Label(root, image=mic_active_icon, cursor="hand2")
 mic_button.place(relx=1.0, rely=0.0, anchor="ne", x=-10, y=10)
-mic_status_label = tk.Label(root, text="Mic: Listening", fg="green", font=("Arial", 10, "bold"))
+mic_status_label = tk.Label(
+    root, text="Mic: Listening", fg="green", font=("Arial", 10, "bold")
+)
 mic_status_label.place(relx=1.0, rely=0.0, anchor="ne", x=-60, y=20)
 
 mic_hard_muted = False
+
 
 def update_mic_overlay():
     if mic_hard_muted:
@@ -298,6 +325,7 @@ def update_mic_overlay():
         mic_status_label.config(text="Mic: Sleeping", fg="red")
     root.after(400, update_mic_overlay)
 
+
 def on_mic_click(event=None):
     global mic_hard_muted
     mic_hard_muted = not mic_hard_muted
@@ -309,12 +337,16 @@ def on_mic_click(event=None):
         output.insert(tk.END, "Assistant: 🎤 Assistant unmuted by overlay.\n")
     update_mic_overlay()
 
+
 mic_button.bind("<Button-1>", on_mic_click)
 update_mic_overlay()
 
 # ========== ACTIVITY STATUS ==========
-status_label = ttk.Label(root, text="Ready", foreground="green", font=("Arial", 10, "bold"))
+status_label = ttk.Label(
+    root, text="Ready", foreground="green", font=("Arial", 10, "bold")
+)
 status_label.place(relx=0.0, rely=1.0, anchor="sw", x=10, y=-10)
+
 
 def update_status_label():
     if is_speaking():
@@ -325,9 +357,11 @@ def update_status_label():
         status_label.config(text="Ready", foreground="green")
     root.after(200, update_status_label)
 
+
 update_status_label()
 
 # ========== SCREEN VIEWER WINDOW ==========
+
 
 class ScreenViewer(tk.Toplevel):
     """Live screen capture window with simple macro controls."""
@@ -343,19 +377,27 @@ class ScreenViewer(tk.Toplevel):
         self.label.pack()
         btn_frame = tk.Frame(self)
         btn_frame.pack(pady=5)
-        tk.Button(btn_frame, text="Record Macro", command=self.start_record).pack(side=tk.LEFT, padx=5)
-        tk.Button(btn_frame, text="Stop Recording", command=self.stop_record).pack(side=tk.LEFT, padx=5)
-        tk.Button(btn_frame, text="Play Macro", command=self.play_macro).pack(side=tk.LEFT, padx=5)
+        tk.Button(btn_frame, text="Record Macro", command=self.start_record).pack(
+            side=tk.LEFT, padx=5
+        )
+        tk.Button(btn_frame, text="Stop Recording", command=self.stop_record).pack(
+            side=tk.LEFT, padx=5
+        )
+        tk.Button(btn_frame, text="Play Macro", command=self.play_macro).pack(
+            side=tk.LEFT, padx=5
+        )
         self._update_frame()
 
     def _grab_screen(self):
         try:
             from PIL import ImageGrab, ImageTk  # type: ignore
+
             img = ImageGrab.grab()
             return ImageTk.PhotoImage(img)
         except Exception:
             try:
                 import pyautogui
+
                 img = pyautogui.screenshot()
                 return ImageTk.PhotoImage(img)
             except Exception:
@@ -395,6 +437,7 @@ class ScreenViewer(tk.Toplevel):
             return
         try:
             import keyboard
+
             keyboard.press_and_release("esc")
         except Exception:
             pass
@@ -404,6 +447,7 @@ class ScreenViewer(tk.Toplevel):
             return
         try:
             from modules.automation_learning import play_events
+
             play_events(self.recorded_events)
         except Exception:
             pass
@@ -413,7 +457,9 @@ class ScreenViewer(tk.Toplevel):
             self.after_cancel(self._after_id)
         super().destroy()
 
+
 screen_viewer_window: ScreenViewer | None = None
+
 
 def open_screen_viewer():
     """Open or focus the ScreenViewer window."""
@@ -423,6 +469,7 @@ def open_screen_viewer():
         return screen_viewer_window
     screen_viewer_window = ScreenViewer(master=root)
     return screen_viewer_window
+
 
 set_screen_viewer_callback(open_screen_viewer)
 
@@ -434,11 +481,15 @@ def send():
     # Use imported process_input, pass the UI output widget for responses
     if user_input.strip():
         debug_panel.add_command(user_input)
-    threading.Thread(target=process_input, args=(user_input, output), daemon=True).start()
+    threading.Thread(
+        target=process_input, args=(user_input, output), daemon=True
+    ).start()
+
 
 # ===== Task Entry Handlers =====
 task_history = []
 history_index = 0
+
 
 def send_task(event=None):
     """Send natural-language task description to the assistant."""
@@ -450,7 +501,10 @@ def send_task(event=None):
     task_history.append(user_input)
     history_index = len(task_history)
     debug_panel.add_command(user_input)
-    threading.Thread(target=process_input, args=(user_input, output), daemon=True).start()
+    threading.Thread(
+        target=process_input, args=(user_input, output), daemon=True
+    ).start()
+
 
 def show_prev_task(event):
     global history_index
@@ -458,6 +512,7 @@ def show_prev_task(event):
         history_index -= 1
         task_entry.delete(0, tk.END)
         task_entry.insert(0, task_history[history_index])
+
 
 def show_next_task(event):
     global history_index
@@ -468,6 +523,8 @@ def show_next_task(event):
     else:
         task_entry.delete(0, tk.END)
     # ========== “Reload Config” Button and Handler=================
+
+
 def reload_config():
     global config
     config = config_loader.reload()
@@ -488,6 +545,7 @@ def reload_config():
     current_voice = config.get("tts_voice") or voice_var.get()
     voice_var.set(current_voice)
 
+
 # ========== BUTTON HANDLER (UI ONLY) ==========
 buttons_frame = ttk.Frame(entry_frame)
 buttons_frame.pack(side=tk.LEFT)
@@ -498,13 +556,18 @@ task_button = ttk.Button(buttons_frame, text="Run Task", command=send_task)
 task_button.pack(side=tk.LEFT, padx=(0, 5))
 reload_button = ttk.Button(buttons_frame, text="Reload Config", command=reload_config)
 reload_button.pack(side=tk.LEFT, padx=(0, 5))
-memory_button = ttk.Button(buttons_frame, text="Edit Memory", command=open_memory_window)
+memory_button = ttk.Button(
+    buttons_frame, text="Edit Memory", command=open_memory_window
+)
 memory_button.pack(side=tk.LEFT, padx=(0, 5))
-screen_button = ttk.Button(buttons_frame, text="What's on my screen?", command=open_screen_viewer)
+screen_button = ttk.Button(
+    buttons_frame, text="What's on my screen?", command=open_screen_viewer
+)
 
 screen_button.pack(side=tk.LEFT, padx=(0, 5))
 
 debug_window: debug_panel.DebugOverlay | None = None
+
 
 def toggle_debug_panel() -> None:
     global debug_window
@@ -515,9 +578,9 @@ def toggle_debug_panel() -> None:
     else:
         debug_window = debug_panel.DebugOverlay(master=root)
 
+
 debug_button = ttk.Button(buttons_frame, text="Debug", command=toggle_debug_panel)
 debug_button.pack(side=tk.LEFT, padx=(0, 5))
-
 
 
 # ========== TTS SPEED SLIDER ==========
@@ -554,7 +617,13 @@ voices = tts_module.list_voices()
 voice_var = tk.StringVar()
 current_voice = config.get("tts_voice") or (voices[0] if voices else "")
 voice_var.set(current_voice)
-voice_menu = ttk.OptionMenu(tts_frame, voice_var, current_voice, *voices, command=lambda v: tts_module.set_voice(v))
+voice_menu = ttk.OptionMenu(
+    tts_frame,
+    voice_var,
+    current_voice,
+    *voices,
+    command=lambda v: tts_module.set_voice(v),
+)
 voice_menu.configure(text="TTS Voice")
 voice_menu.pack(side=tk.LEFT)
 
@@ -576,11 +645,13 @@ sleep_entry.grid(row=1, column=1, sticky="w")
 assign_status = ttk.Label(assign_frame, text="")
 assign_status.grid(row=3, column=0, columnspan=2, pady=(5, 0))
 
+
 def apply_hotkeys() -> None:
     msg = wake_sleep_hotkey.set_hotkeys(
         wake_hotkey_var.get().strip(), sleep_hotkey_var.get().strip()
     )
     assign_status.config(text=msg)
+
 
 ttk.Button(assign_frame, text="Apply Hotkeys", command=apply_hotkeys).grid(
     row=2, column=0, columnspan=2, pady=(5, 5)
@@ -611,6 +682,7 @@ def start_macro_recording() -> None:
         from modules import automation_learning
 
         path = automation_learning.record_macro(name)
+
         def _cb() -> None:
             macro_status.config(text=f"Saved to {path}")
             update_macro_buttons()
@@ -639,6 +711,7 @@ macro_buttons_frame = ttk.Frame(macro_frame)
 macro_buttons_frame.pack(fill="both", expand=True)
 macro_buttons: list[ttk.Button] = []
 
+
 def _run_macro(name: str) -> None:
     """Play the macro ``name`` and show status."""
     from modules.automation_learning import play_macro
@@ -661,9 +734,7 @@ def update_macro_buttons() -> None:
                 command=lambda n=name: _run_macro(n),
             )
         else:
-            btn.configure(
-                text=f"Slot {i + 1}", command=lambda: None, state=tk.DISABLED
-            )
+            btn.configure(text=f"Slot {i + 1}", command=lambda: None, state=tk.DISABLED)
 
 
 for r in range(5):
@@ -756,12 +827,19 @@ openai_var = tk.StringVar(value=config.get("api_keys", {}).get("openai", ""))
 anthropic_var = tk.StringVar(value=config.get("api_keys", {}).get("anthropic", ""))
 google_var = tk.StringVar(value=config.get("api_keys", {}).get("google", ""))
 ttk.Label(api_frame, text="OpenAI:").grid(row=0, column=0, sticky="w")
-ttk.Entry(api_frame, textvariable=openai_var, width=40).grid(row=0, column=1, sticky="ew")
+ttk.Entry(api_frame, textvariable=openai_var, width=40).grid(
+    row=0, column=1, sticky="ew"
+)
 ttk.Label(api_frame, text="Anthropic:").grid(row=1, column=0, sticky="w")
-ttk.Entry(api_frame, textvariable=anthropic_var, width=40).grid(row=1, column=1, sticky="ew")
+ttk.Entry(api_frame, textvariable=anthropic_var, width=40).grid(
+    row=1, column=1, sticky="ew"
+)
 ttk.Label(api_frame, text="Google:").grid(row=2, column=0, sticky="w")
-ttk.Entry(api_frame, textvariable=google_var, width=40).grid(row=2, column=1, sticky="ew")
+ttk.Entry(api_frame, textvariable=google_var, width=40).grid(
+    row=2, column=1, sticky="ew"
+)
 api_frame.columnconfigure(1, weight=1)
+
 
 def save_api_keys() -> None:
     keys = {
@@ -772,18 +850,24 @@ def save_api_keys() -> None:
     api_keys.save_api_keys(keys)
     gen_status.config(text="API keys saved.")
 
-ttk.Button(api_frame, text="Save Keys", command=save_api_keys).grid(row=3, column=0, columnspan=2, pady=5)
+
+ttk.Button(api_frame, text="Save Keys", command=save_api_keys).grid(
+    row=3, column=0, columnspan=2, pady=5
+)
 
 # Provider selection
 provider_var = tk.StringVar(value="openai")
 ttk.Label(module_tab, text="Provider:").pack(anchor="w", padx=10)
-ttk.OptionMenu(module_tab, provider_var, "openai", "openai", "anthropic", "google").pack(anchor="w", padx=10)
+ttk.OptionMenu(
+    module_tab, provider_var, "openai", "openai", "anthropic", "google"
+).pack(anchor="w", padx=10)
 
 ttk.Label(module_tab, text="Preview:").pack(anchor="w", padx=10, pady=(10, 0))
 gen_preview = tk.Text(module_tab, height=15)
 gen_preview.pack(fill="both", expand=True, padx=10)
 gen_status = ttk.Label(module_tab, text="")
 gen_status.pack(anchor="w", padx=10, pady=(5, 0))
+
 
 def generate_preview() -> None:
     desc = gen_desc.get("1.0", tk.END).strip()
@@ -807,7 +891,9 @@ def generate_preview() -> None:
     except Exception as exc:  # pragma: no cover - network failure
         gen_status.config(text=f"Error: {exc}")
 
+
 generate_preview.current_code = ""
+
 
 def save_generated() -> None:
     code = generate_preview.current_code
@@ -827,6 +913,7 @@ def save_generated() -> None:
     except Exception as exc:
         gen_status.config(text=f"Error: {exc}")
 
+
 def cancel_generated() -> None:
     gen_preview.delete("1.0", tk.END)
     save_btn.config(state=tk.DISABLED)
@@ -834,13 +921,18 @@ def cancel_generated() -> None:
     generate_preview.current_code = ""
     gen_status.config(text="Cancelled")
 
+
 btn_frame_gen = ttk.Frame(module_tab)
 btn_frame_gen.pack(pady=5)
 gen_btn = ttk.Button(btn_frame_gen, text="Generate Preview", command=generate_preview)
 gen_btn.pack(side=tk.LEFT, padx=5)
-save_btn = ttk.Button(btn_frame_gen, text="Save Module", state=tk.DISABLED, command=save_generated)
+save_btn = ttk.Button(
+    btn_frame_gen, text="Save Module", state=tk.DISABLED, command=save_generated
+)
 save_btn.pack(side=tk.LEFT, padx=5)
-cancel_btn = ttk.Button(btn_frame_gen, text="Cancel", state=tk.DISABLED, command=cancel_generated)
+cancel_btn = ttk.Button(
+    btn_frame_gen, text="Cancel", state=tk.DISABLED, command=cancel_generated
+)
 cancel_btn.pack(side=tk.LEFT, padx=5)
 
 # ---------- Image Generator Tab ----------
@@ -902,11 +994,16 @@ def remove_sd_model() -> None:
     sd_model_manager.save_models(saved_sd_models)
     img_status.config(text=f"Removed {path}")
 
+
 sd_model_list.bind("<Double-Button-1>", select_sd_model)
 btn_sd = ttk.Frame(image_frame)
 btn_sd.pack(pady=(0, 5))
-ttk.Button(btn_sd, text="Save Model Path", command=add_sd_model).pack(side=tk.LEFT, padx=5)
-ttk.Button(btn_sd, text="Remove Selected", command=remove_sd_model).pack(side=tk.LEFT, padx=5)
+ttk.Button(btn_sd, text="Save Model Path", command=add_sd_model).pack(
+    side=tk.LEFT, padx=5
+)
+ttk.Button(btn_sd, text="Remove Selected", command=remove_sd_model).pack(
+    side=tk.LEFT, padx=5
+)
 
 sd_device_var = tk.StringVar(value=gpu.get_device())
 ttk.Label(image_frame, text="Device:").pack(anchor="w", padx=10, pady=(5, 0))
@@ -921,12 +1018,15 @@ sd_device_menu.pack(anchor="w", padx=10)
 
 size_var = tk.StringVar(value="512x512")
 ttk.Label(image_frame, text="Size:").pack(anchor="w", padx=10, pady=(5, 0))
-ttk.OptionMenu(image_frame, size_var, "512x512", "256x256", "512x512", "1024x1024").pack(anchor="w", padx=10)
+ttk.OptionMenu(
+    image_frame, size_var, "512x512", "256x256", "512x512", "1024x1024"
+).pack(anchor="w", padx=10)
 
 img_dir_var = tk.StringVar(value="generated_images")
 ttk.Label(image_frame, text="Save Folder:").pack(anchor="w", padx=10, pady=(5, 0))
 img_dir_entry = ttk.Entry(image_frame, textvariable=img_dir_var, width=50)
 img_dir_entry.pack(fill="x", padx=10)
+
 
 def open_folder(path: str) -> None:
     if not os.path.isabs(path):
@@ -943,7 +1043,11 @@ def open_folder(path: str) -> None:
         img_status.config(text=f"Failed to open: {exc}")
 
 
-ttk.Button(image_frame, text="Open Folder", command=lambda: open_folder(img_dir_var.get())).pack(anchor="w", padx=10, pady=(0, 5))
+ttk.Button(
+    image_frame,
+    text="Open Folder",
+    command=lambda: open_folder(img_dir_var.get()),
+).pack(anchor="w", padx=10, pady=(0, 5))
 
 
 img_name_var = tk.StringVar(value="")
@@ -951,15 +1055,24 @@ ttk.Label(image_frame, text="File Name:").pack(anchor="w", padx=10, pady=(5, 0))
 img_name_entry = ttk.Entry(image_frame, textvariable=img_name_var, width=50)
 img_name_entry.pack(fill="x", padx=10)
 
+
 def toggle_source(*_args) -> None:
     """Enable or disable local model fields based on ``source_var``."""
     state = tk.NORMAL if source_var.get() == "local" else tk.DISABLED
     sd_model_entry.config(state=state)
     sd_device_menu.config(state=state)
 
+
 toggle_source()
 
-img_canvas = tk.Canvas(image_frame, width=256, height=256, bg="white", highlightthickness=1, highlightbackground="gray")
+img_canvas = tk.Canvas(
+    image_frame,
+    width=256,
+    height=256,
+    bg="white",
+    highlightthickness=1,
+    highlightbackground="gray",
+)
 img_canvas.pack(pady=10)
 img_status = ttk.Label(image_frame, text="")
 img_status.pack(anchor="w", padx=10, pady=(5, 0))
@@ -1000,6 +1113,7 @@ def _start_eta_timer(start: float) -> None:
             img_canvas.after(1000, _update)
 
     _update()
+
 
 def generate_image_btn() -> None:
     prompt = img_prompt.get("1.0", tk.END).strip()
@@ -1052,7 +1166,6 @@ def generate_image_btn() -> None:
         img_status.after(0, _update)
 
     threading.Thread(target=_run, daemon=True).start()
-
 
 
 def imagine_via_gui(
@@ -1131,6 +1244,7 @@ def imagine_via_gui(
     root.after(0, _finish)
     return path
 
+
 imagine_generator.set_gui_callback(imagine_via_gui)
 
 ttk.Button(image_tab, text="Generate Image", command=generate_image_btn).pack(pady=5)
@@ -1155,9 +1269,58 @@ ttk.Label(video_frame, text="Local Model Path:").pack(anchor="w", padx=10, pady=
 video_model_entry = ttk.Entry(video_frame, textvariable=video_model_var, width=50)
 video_model_entry.pack(fill="x", padx=10)
 
+saved_video_models = video_model_manager.load_models()
+video_model_list = tk.Listbox(video_frame, height=3)
+for _m in saved_video_models:
+    video_model_list.insert(tk.END, _m)
+video_model_list.pack(fill="x", padx=10, pady=(5, 0))
+
+
+def select_video_model(_event=None) -> None:
+    if video_model_list.curselection():
+        video_model_var.set(video_model_list.get(video_model_list.curselection()[0]))
+
+
+def add_video_model() -> None:
+    path = video_model_var.get().strip()
+    if not path:
+        video_status.config(text="Enter a model path first.")
+        return
+    if path not in saved_video_models:
+        saved_video_models.append(path)
+        video_model_manager.save_models(saved_video_models)
+        video_model_list.insert(tk.END, path)
+        video_status.config(text=f"Saved {path}")
+    else:
+        video_status.config(text="Model already saved.")
+
+
+def remove_video_model() -> None:
+    if not video_model_list.curselection():
+        video_status.config(text="Select a model to remove.")
+        return
+    idx = video_model_list.curselection()[0]
+    path = saved_video_models.pop(idx)
+    video_model_list.delete(idx)
+    video_model_manager.save_models(saved_video_models)
+    video_status.config(text=f"Removed {path}")
+
+
+video_model_list.bind("<Double-Button-1>", select_video_model)
+btn_vm = ttk.Frame(video_frame)
+btn_vm.pack(pady=(0, 5))
+ttk.Button(btn_vm, text="Save Model Path", command=add_video_model).pack(
+    side=tk.LEFT, padx=5
+)
+ttk.Button(btn_vm, text="Remove Selected", command=remove_video_model).pack(
+    side=tk.LEFT, padx=5
+)
+
 video_device_var = tk.StringVar(value=gpu.get_device())
 ttk.Label(video_frame, text="Device:").pack(anchor="w", padx=10, pady=(5, 0))
-ttk.OptionMenu(video_frame, video_device_var, "cpu", "cpu", "cuda").pack(anchor="w", padx=10)
+ttk.OptionMenu(video_frame, video_device_var, "cpu", "cpu", "cuda").pack(
+    anchor="w", padx=10
+)
 
 fps_var = tk.StringVar(value="8")
 ttk.Label(video_frame, text="FPS:").pack(anchor="w", padx=10, pady=(5, 0))
@@ -1171,14 +1334,25 @@ video_dir_var = tk.StringVar(value="generated_videos")
 ttk.Label(video_frame, text="Save Folder:").pack(anchor="w", padx=10, pady=(5, 0))
 video_dir_entry = ttk.Entry(video_frame, textvariable=video_dir_var, width=50)
 video_dir_entry.pack(fill="x", padx=10)
-ttk.Button(video_frame, text="Open Folder", command=lambda: open_folder(video_dir_var.get())).pack(anchor="w", padx=10, pady=(0, 5))
+ttk.Button(
+    video_frame,
+    text="Open Folder",
+    command=lambda: open_folder(video_dir_var.get()),
+).pack(anchor="w", padx=10, pady=(0, 5))
 
 video_name_var = tk.StringVar(value="")
 ttk.Label(video_frame, text="File Name:").pack(anchor="w", padx=10, pady=(5, 0))
 video_name_entry = ttk.Entry(video_frame, textvariable=video_name_var, width=50)
 video_name_entry.pack(fill="x", padx=10)
 
-video_canvas = tk.Canvas(video_frame, width=256, height=256, bg="white", highlightthickness=1, highlightbackground="gray")
+video_canvas = tk.Canvas(
+    video_frame,
+    width=256,
+    height=256,
+    bg="white",
+    highlightthickness=1,
+    highlightbackground="gray",
+)
 video_canvas.pack(pady=10)
 
 video_status = ttk.Label(video_frame, text="")
@@ -1236,6 +1410,7 @@ def generate_video_btn() -> None:
 
     threading.Thread(target=_run, daemon=True).start()
 
+
 ttk.Button(video_frame, text="Generate Video", command=generate_video_btn).pack(pady=5)
 
 # ---------- Stable Fast 3D Tab ----------
@@ -1247,15 +1422,68 @@ ttk.Label(fast3d_tab, text="Model Path:").pack(anchor="w", padx=10, pady=(5, 0))
 fast3d_model_entry = ttk.Entry(fast3d_tab, textvariable=fast3d_model_var, width=50)
 fast3d_model_entry.pack(fill="x", padx=10)
 
+saved_fast3d_models = fast3d_model_manager.load_models()
+fast3d_model_list = tk.Listbox(fast3d_tab, height=3)
+for _m in saved_fast3d_models:
+    fast3d_model_list.insert(tk.END, _m)
+fast3d_model_list.pack(fill="x", padx=10, pady=(5, 0))
+
+
+def select_fast3d_model(_event=None) -> None:
+    if fast3d_model_list.curselection():
+        fast3d_model_var.set(fast3d_model_list.get(fast3d_model_list.curselection()[0]))
+
+
+def add_fast3d_model() -> None:
+    path = fast3d_model_var.get().strip()
+    if not path:
+        fast3d_status.config(text="Enter a model path first.")
+        return
+    if path not in saved_fast3d_models:
+        saved_fast3d_models.append(path)
+        fast3d_model_manager.save_models(saved_fast3d_models)
+        fast3d_model_list.insert(tk.END, path)
+        fast3d_status.config(text=f"Saved {path}")
+    else:
+        fast3d_status.config(text="Model already saved.")
+
+
+def remove_fast3d_model() -> None:
+    if not fast3d_model_list.curselection():
+        fast3d_status.config(text="Select a model to remove.")
+        return
+    idx = fast3d_model_list.curselection()[0]
+    path = saved_fast3d_models.pop(idx)
+    fast3d_model_list.delete(idx)
+    fast3d_model_manager.save_models(saved_fast3d_models)
+    fast3d_status.config(text=f"Removed {path}")
+
+
+fast3d_model_list.bind("<Double-Button-1>", select_fast3d_model)
+btn_fast3d = ttk.Frame(fast3d_tab)
+btn_fast3d.pack(pady=(0, 5))
+ttk.Button(btn_fast3d, text="Save Model Path", command=add_fast3d_model).pack(
+    side=tk.LEFT, padx=5
+)
+ttk.Button(btn_fast3d, text="Remove Selected", command=remove_fast3d_model).pack(
+    side=tk.LEFT, padx=5
+)
+
 fast3d_device_var = tk.StringVar(value=gpu.get_device())
 ttk.Label(fast3d_tab, text="Device:").pack(anchor="w", padx=10, pady=(5, 0))
-ttk.OptionMenu(fast3d_tab, fast3d_device_var, "cpu", "cpu", "cuda").pack(anchor="w", padx=10)
+ttk.OptionMenu(fast3d_tab, fast3d_device_var, "cpu", "cpu", "cuda").pack(
+    anchor="w", padx=10
+)
 
 fast3d_dir_var = tk.StringVar(value="generated_3d")
 ttk.Label(fast3d_tab, text="Save Folder:").pack(anchor="w", padx=10, pady=(5, 0))
 fast3d_dir_entry = ttk.Entry(fast3d_tab, textvariable=fast3d_dir_var, width=50)
 fast3d_dir_entry.pack(fill="x", padx=10)
-ttk.Button(fast3d_tab, text="Open Folder", command=lambda: open_folder(fast3d_dir_var.get())).pack(anchor="w", padx=10, pady=(0, 5))
+ttk.Button(
+    fast3d_tab,
+    text="Open Folder",
+    command=lambda: open_folder(fast3d_dir_var.get()),
+).pack(anchor="w", padx=10, pady=(0, 5))
 
 fast3d_name_var = tk.StringVar(value="")
 ttk.Label(fast3d_tab, text="File Name:").pack(anchor="w", padx=10, pady=(5, 0))
@@ -1323,6 +1551,7 @@ def generate_fast3d_btn() -> None:
 
     threading.Thread(target=_run, daemon=True).start()
 
+
 ttk.Button(fast3d_tab, text="Generate Model", command=generate_fast3d_btn).pack(pady=5)
 
 # ---------- Web Activity Tab ----------
@@ -1380,11 +1609,15 @@ set_webview_callback(_load_url)
 
 # ---------- Settings Tab ----------
 use_remote_var = tk.BooleanVar(value=bool(config.get("llm_url")))
-url_var = tk.StringVar(value=config.get("llm_url", "http://localhost:11434/v1/chat/completions"))
+url_var = tk.StringVar(
+    value=config.get("llm_url", "http://localhost:11434/v1/chat/completions")
+)
+
 
 def _toggle_remote() -> None:
     state = tk.NORMAL if use_remote_var.get() else tk.DISABLED
     url_entry.config(state=state)
+
 
 ttk.Checkbutton(
     settings_tab,
@@ -1399,6 +1632,7 @@ url_entry.pack(fill="x", padx=10)
 
 # Settings tab currently only supports toggling remote LLM usage
 
+
 def save_settings() -> None:
     cfg = config_loader.config
     if use_remote_var.get():
@@ -1410,6 +1644,7 @@ def save_settings() -> None:
     config_loader.config = cfg
     output.insert(tk.END, "[SYSTEM] Settings saved.\n")
     reload_config()
+
 
 ttk.Button(settings_tab, text="Save Settings", command=save_settings).pack(pady=10)
 _toggle_remote()
@@ -1460,6 +1695,7 @@ def run_sentence():
 def run_paragraph():
     _run_learning(speech_learning.PARAGRAPH_PROMPTS, paragraph_result)
 
+
 wake_frame = ttk.Frame(speech_tab)
 wake_frame.pack(fill="x", padx=10, pady=5)
 wake_btn = ttk.Button(wake_frame, text="Learn Wake/Sleep", command=run_wake_sleep)
@@ -1467,7 +1703,9 @@ wake_btn.pack(side=tk.LEFT, padx=(0, 5))
 wake_col = ttk.Frame(wake_frame)
 wake_col.pack(side=tk.LEFT, fill="both", expand=True)
 ttk.Label(wake_col, text="\n".join(speech_learning.WAKE_SLEEP_PROMPTS)).pack(anchor="w")
-wake_result = ReadOnlyText(wake_col, height=len(speech_learning.WAKE_SLEEP_PROMPTS), width=60, wrap=tk.WORD)
+wake_result = ReadOnlyText(
+    wake_col, height=len(speech_learning.WAKE_SLEEP_PROMPTS), width=60, wrap=tk.WORD
+)
 wake_result.pack(fill="x")
 
 sentence_frame = ttk.Frame(speech_tab)
@@ -1476,8 +1714,12 @@ sentence_btn = ttk.Button(sentence_frame, text="Sentence", command=run_sentence)
 sentence_btn.pack(side=tk.LEFT, padx=(0, 5))
 sentence_col = ttk.Frame(sentence_frame)
 sentence_col.pack(side=tk.LEFT, fill="both", expand=True)
-ttk.Label(sentence_col, text="\n".join(speech_learning.SENTENCE_PROMPTS)).pack(anchor="w")
-sentence_result = ReadOnlyText(sentence_col, height=len(speech_learning.SENTENCE_PROMPTS), width=60, wrap=tk.WORD)
+ttk.Label(sentence_col, text="\n".join(speech_learning.SENTENCE_PROMPTS)).pack(
+    anchor="w"
+)
+sentence_result = ReadOnlyText(
+    sentence_col, height=len(speech_learning.SENTENCE_PROMPTS), width=60, wrap=tk.WORD
+)
 sentence_result.pack(fill="x")
 
 paragraph_frame = ttk.Frame(speech_tab)
@@ -1486,7 +1728,9 @@ paragraph_btn = ttk.Button(paragraph_frame, text="Paragraph", command=run_paragr
 paragraph_btn.pack(side=tk.LEFT, padx=(0, 5))
 paragraph_col = ttk.Frame(paragraph_frame)
 paragraph_col.pack(side=tk.LEFT, fill="both", expand=True)
-ttk.Label(paragraph_col, text="\n".join(speech_learning.PARAGRAPH_PROMPTS)).pack(anchor="w")
+ttk.Label(paragraph_col, text="\n".join(speech_learning.PARAGRAPH_PROMPTS)).pack(
+    anchor="w"
+)
 paragraph_result = ReadOnlyText(paragraph_col, height=3, width=60, wrap=tk.WORD)
 paragraph_result.pack(fill="x")
 
@@ -1495,9 +1739,14 @@ paragraph_result.pack(fill="x")
 wake_sleep_hotkey.start_hotkeys()
 threading.Thread(
     target=start_voice_listener,
-    args=(output, VOSK_MODEL_PATH, lambda: mic_hard_muted),  # UI output, model path, mic state
-    daemon=True
+    args=(
+        output,
+        VOSK_MODEL_PATH,
+        lambda: mic_hard_muted,
+    ),  # UI output, model path, mic state
+    daemon=True,
 ).start()
+
 
 # ========== SYSTEM TRAY ICON ==========
 def make_icon_image():
@@ -1509,17 +1758,18 @@ def make_icon_image():
     draw.text((18, 24), "AI", fill="white")
     return img
 
+
 def start_tray():
     def tray_start_listening(icon, item):
         set_listening(True)
         speak("I'm listening.")
-        output.insert(tk.END, "\U0001F399\ufe0f Listening started via tray.\n")
+        output.insert(tk.END, "\U0001f399\ufe0f Listening started via tray.\n")
         output.see("end")
 
     def tray_stop_listening(icon, item):
         set_listening(False)
         speak("Going to sleep.")
-        output.insert(tk.END, "\U0001F634 Listening stopped via tray.\n")
+        output.insert(tk.END, "\U0001f634 Listening stopped via tray.\n")
         output.see("end")
 
     def tray_quit(icon, item):
@@ -1540,12 +1790,13 @@ def start_tray():
             pystray.MenuItem("Hide", lambda _: root.withdraw()),
             pystray.MenuItem("Start Listening", tray_start_listening),
             pystray.MenuItem("Stop Listening", tray_stop_listening),
-            pystray.MenuItem("Quit", tray_quit)
-        )
+            pystray.MenuItem("Quit", tray_quit),
+        ),
     )
     tray_icon = icon
     icon.run()
     tray_icon = None
+
 
 def stop_tray():
     """Stop and clear the tray icon if running."""
@@ -1553,6 +1804,7 @@ def stop_tray():
     if tray_icon is not None:
         tray_icon.stop()
         tray_icon = None
+
 
 if pystray is not None:
     threading.Thread(target=start_tray, daemon=True).start()
@@ -1564,8 +1816,15 @@ if not os.environ.get("PYTEST_CURRENT_TEST"):
     _fit_window()
 
 # ========== WELCOME MESSAGE ==========
-output.insert(tk.END, "Assistant: Welcome to your local AI assistant! Speak or type your prompt.\n")
-output.insert(tk.END, "Assistant: Try: capture region 100 200 300 300  | click image red_button.png\n\n")
+output.insert(
+    tk.END,
+    "Assistant: Welcome to your local AI assistant! Speak or type your prompt.\n",
+)
+output.insert(
+    tk.END,
+    "Assistant: Try: capture region 100 200 300 300  | click image red_button.png\n\n",
+)
+
 
 # ========= Watcher Thread ========
 def start_config_watcher():
@@ -1573,7 +1832,9 @@ def start_config_watcher():
         print("[ConfigWatcher] watchdog not available; config auto-reload disabled")
         return
     config_path = "config.json"
-    handler = ConfigFileChangeHandler(reload_callback=reload_config, config_path=config_path)
+    handler = ConfigFileChangeHandler(
+        reload_callback=reload_config, config_path=config_path
+    )
     observer = Observer()
     observer.schedule(handler, path=".", recursive=False)
     observer.start()
@@ -1581,6 +1842,7 @@ def start_config_watcher():
     # Keep observer running (background)
     while True:
         time.sleep(1)
+
 
 # Start watcher thread if watchdog is available
 if WATCHDOG_AVAILABLE:

--- a/modules/fast3d_model_manager.py
+++ b/modules/fast3d_model_manager.py
@@ -1,0 +1,88 @@
+"""Manage saved Stable Fast 3D model paths."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List
+
+from modules.utils import resource_path
+
+MODULE_NAME = "fast3d_model_manager"
+MODELS_FILE = resource_path("fast3d_models.json")
+
+model_paths: List[str] = []
+
+__all__ = [
+    "load_models",
+    "save_models",
+    "add_model",
+    "remove_model",
+    "get_info",
+    "get_description",
+]
+
+
+def load_models() -> List[str]:
+    """Load saved model paths from :data:`MODELS_FILE`."""
+    global model_paths
+    try:
+        with open(MODELS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            model_paths = [str(p) for p in data if isinstance(p, str)]
+        else:
+            model_paths = []
+    except Exception:
+        model_paths = []
+    return model_paths
+
+
+def save_models(models: List[str] | None = None) -> None:
+    """Persist ``models`` to :data:`MODELS_FILE`."""
+    if models is None:
+        models = model_paths
+    with open(MODELS_FILE, "w", encoding="utf-8") as f:
+        json.dump(models, f, indent=2)
+
+
+def add_model(path: str) -> None:
+    """Add ``path`` to :data:`model_paths` and save."""
+    if not path:
+        return
+    if path not in model_paths:
+        model_paths.append(path)
+        save_models()
+
+
+def remove_model(path: str) -> bool:
+    """Remove ``path`` from :data:`model_paths` if present."""
+    try:
+        model_paths.remove(path)
+        save_models()
+        return True
+    except ValueError:
+        return False
+
+
+def get_info() -> dict:
+    """Return module metadata for discovery."""
+    return {
+        "name": MODULE_NAME,
+        "description": get_description(),
+        "functions": [
+            "load_models",
+            "save_models",
+            "add_model",
+            "remove_model",
+        ],
+    }
+
+
+def get_description() -> str:
+    """Return a short description of this module."""
+    return "Manage saved 3D model generation paths."
+
+
+# Initialize on import
+load_models()

--- a/modules/video_model_manager.py
+++ b/modules/video_model_manager.py
@@ -1,0 +1,88 @@
+"""Manage saved Stable Video Diffusion model paths."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List
+
+from modules.utils import resource_path
+
+MODULE_NAME = "video_model_manager"
+MODELS_FILE = resource_path("video_models.json")
+
+model_paths: List[str] = []
+
+__all__ = [
+    "load_models",
+    "save_models",
+    "add_model",
+    "remove_model",
+    "get_info",
+    "get_description",
+]
+
+
+def load_models() -> List[str]:
+    """Load saved model paths from :data:`MODELS_FILE`."""
+    global model_paths
+    try:
+        with open(MODELS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            model_paths = [str(p) for p in data if isinstance(p, str)]
+        else:
+            model_paths = []
+    except Exception:
+        model_paths = []
+    return model_paths
+
+
+def save_models(models: List[str] | None = None) -> None:
+    """Persist ``models`` to :data:`MODELS_FILE`."""
+    if models is None:
+        models = model_paths
+    with open(MODELS_FILE, "w", encoding="utf-8") as f:
+        json.dump(models, f, indent=2)
+
+
+def add_model(path: str) -> None:
+    """Add ``path`` to :data:`model_paths` and save."""
+    if not path:
+        return
+    if path not in model_paths:
+        model_paths.append(path)
+        save_models()
+
+
+def remove_model(path: str) -> bool:
+    """Remove ``path`` from :data:`model_paths` if present."""
+    try:
+        model_paths.remove(path)
+        save_models()
+        return True
+    except ValueError:
+        return False
+
+
+def get_info() -> dict:
+    """Return module metadata for discovery."""
+    return {
+        "name": MODULE_NAME,
+        "description": get_description(),
+        "functions": [
+            "load_models",
+            "save_models",
+            "add_model",
+            "remove_model",
+        ],
+    }
+
+
+def get_description() -> str:
+    """Return a short description of this module."""
+    return "Manage saved video generation model paths."
+
+
+# Initialize on import
+load_models()

--- a/tests/test_fast3d_model_manager.py
+++ b/tests/test_fast3d_model_manager.py
@@ -1,0 +1,33 @@
+import importlib
+import json
+
+
+def test_add_and_remove_models(tmp_path, monkeypatch):
+    mod = importlib.import_module("modules.fast3d_model_manager")
+    importlib.reload(mod)
+    models_file = tmp_path / "models.json"
+    monkeypatch.setattr(mod, "MODELS_FILE", str(models_file), raising=False)
+    mod.model_paths = []
+    mod.save_models([])
+
+    mod.add_model("one")
+    mod.add_model("two")
+    assert mod.model_paths == ["one", "two"]
+
+    removed = mod.remove_model("one")
+    assert removed is True
+    assert mod.model_paths == ["two"]
+    saved = json.loads(models_file.read_text())
+    assert saved == ["two"]
+
+
+def test_load_models_corruption(tmp_path, monkeypatch):
+    mod = importlib.import_module("modules.fast3d_model_manager")
+    importlib.reload(mod)
+    models_file = tmp_path / "models.json"
+    models_file.write_text("{bad")
+    monkeypatch.setattr(mod, "MODELS_FILE", str(models_file), raising=False)
+    mod.model_paths = ["x"]
+    models = mod.load_models()
+    assert models == []
+    assert mod.model_paths == []

--- a/tests/test_video_model_manager.py
+++ b/tests/test_video_model_manager.py
@@ -1,0 +1,33 @@
+import importlib
+import json
+
+
+def test_add_and_remove_models(tmp_path, monkeypatch):
+    mod = importlib.import_module("modules.video_model_manager")
+    importlib.reload(mod)
+    models_file = tmp_path / "models.json"
+    monkeypatch.setattr(mod, "MODELS_FILE", str(models_file), raising=False)
+    mod.model_paths = []
+    mod.save_models([])
+
+    mod.add_model("one")
+    mod.add_model("two")
+    assert mod.model_paths == ["one", "two"]
+
+    removed = mod.remove_model("one")
+    assert removed is True
+    assert mod.model_paths == ["two"]
+    saved = json.loads(models_file.read_text())
+    assert saved == ["two"]
+
+
+def test_load_models_corruption(tmp_path, monkeypatch):
+    mod = importlib.import_module("modules.video_model_manager")
+    importlib.reload(mod)
+    models_file = tmp_path / "models.json"
+    models_file.write_text("{bad")
+    monkeypatch.setattr(mod, "MODELS_FILE", str(models_file), raising=False)
+    mod.model_paths = ["x"]
+    models = mod.load_models()
+    assert models == []
+    assert mod.model_paths == []


### PR DESCRIPTION
## Summary
- add new modules `video_model_manager` and `fast3d_model_manager`
- update GUI to save video and 3D model paths like Stable Diffusion
- update features in README
- add tests for the new model manager modules

## Testing
- `ruff check .`
- `black -q gui_assistant.py modules/video_model_manager.py modules/fast3d_model_manager.py tests/test_video_model_manager.py tests/test_fast3d_model_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688514cd455083248c4917f4807d1d12