### PR TITLE
Enable LAN auto-discovery for remote assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,11 @@ You can also start and control the remote server via voice commands:
 `"start remote server"`, `"stop remote server"`, and
 `"send remote <host> <port> <command>"`.
 
+### LAN Auto-Discovery
+The ``lan_discovery`` module uses mDNS to broadcast the assistant on your LAN.
+Run ``lan_launcher.py`` or the ``start_lan_assistant`` scripts to automatically
+start a server or connect to one without manually entering an IP address.
+
 Or start the lightweight Flask REST API:
 ```bash
 python -m modules.web_api

--- a/lan_discovery.py
+++ b/lan_discovery.py
@@ -1,0 +1,168 @@
+"""LAN auto-discovery utilities using mDNS (zeroconf).
+
+This module allows the assistant's remote server to advertise itself on the
+local network so that other devices can find and connect without manual
+configuration.
+
+If the optional :mod:`zeroconf` package is missing the functions become
+no-ops so the rest of the assistant can still run.
+"""
+
+from __future__ import annotations
+
+__all__ = ["LanAdvertiser", "discover_services", "choose_mode_gui"]
+
+import socket
+import time
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+try:
+    from zeroconf import (
+        Zeroconf,
+        ServiceInfo,
+        ServiceBrowser,
+        ServiceListener,
+    )
+except Exception as e:  # pragma: no cover - optional dependency
+    Zeroconf = None
+    ServiceInfo = None
+    ServiceBrowser = None
+    ServiceListener = object
+    _IMPORT_ERROR = e
+else:
+    _IMPORT_ERROR = None
+
+SERVICE_TYPE = "_moatassist._tcp.local."
+
+
+def _local_ip() -> str:
+    """Return the current machine's LAN IP or ``127.0.0.1``."""
+    try:
+        # This doesn't actually connect but is enough to get the outgoing IP
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except Exception:
+        try:
+            return socket.gethostbyname(socket.gethostname())
+        except Exception:
+            return "127.0.0.1"
+
+
+@dataclass
+class LanAdvertiser:
+    """Advertise a remote server via mDNS."""
+
+    name: str
+    port: int
+    zeroconf: Zeroconf | None = None
+    _info: ServiceInfo | None = None
+
+    def start(self) -> None:
+        """Start advertising the service."""
+        if Zeroconf is None or ServiceInfo is None:
+            return
+        addr = socket.inet_aton(_local_ip())
+        self.zeroconf = Zeroconf()
+        self._info = ServiceInfo(
+            SERVICE_TYPE,
+            f"{self.name}.{SERVICE_TYPE}",
+            addresses=[addr],
+            port=self.port,
+            properties={},
+        )
+        self.zeroconf.register_service(self._info)
+
+    def stop(self) -> None:
+        """Stop advertising."""
+        if not self.zeroconf or not self._info:
+            return
+        try:
+            self.zeroconf.unregister_service(self._info)
+        finally:
+            self.zeroconf.close()
+            self.zeroconf = None
+            self._info = None
+
+
+class _Listener(ServiceListener):
+    def __init__(self) -> None:
+        self.services: Dict[str, Tuple[str, int]] = {}
+
+    def add_service(self, zeroconf: Zeroconf, type_: str, name: str) -> None:  # type: ignore[override]
+        info = zeroconf.get_service_info(type_, name)
+        if not info or not info.addresses:
+            return
+        address = socket.inet_ntoa(info.addresses[0])
+        self.services[name] = (address, info.port)
+
+
+def discover_services(timeout: float = 2.0) -> Dict[str, Tuple[str, int]]:
+    """Discover advertised assistant servers on the LAN."""
+    if Zeroconf is None:
+        return {}
+    zeroconf = Zeroconf()
+    listener = _Listener()
+    browser = ServiceBrowser(zeroconf, SERVICE_TYPE, listener)  # noqa: F841
+    time.sleep(timeout)
+    zeroconf.close()
+    return listener.services
+
+
+def choose_mode_gui() -> str:
+    """Return ``"server"`` or ``"client"`` using a tiny GUI if available."""
+    # Prefer PySide6 if installed for a modern look
+    if _IMPORT_ERROR:
+        return "server"
+    try:
+        from PySide6.QtWidgets import (
+            QApplication,
+            QPushButton,
+            QVBoxLayout,
+            QWidget,
+            QLabel,
+        )
+    except Exception:
+        try:
+            import tkinter as tk  # type: ignore
+        except Exception:
+            return "server"
+        sel = {"mode": "server"}
+        root = tk.Tk()
+        root.title("LAN Assistant")
+        tk.Label(root, text="Select mode").pack(padx=20, pady=10)
+
+        def set_mode(m: str) -> None:
+            sel["mode"] = m
+            root.destroy()
+
+        tk.Button(root, text="Server", command=lambda: set_mode("server")).pack(fill="x")
+        tk.Button(root, text="Client", command=lambda: set_mode("client")).pack(fill="x")
+        root.mainloop()
+        return sel["mode"]
+    else:
+        app = QApplication([])
+        sel = {"mode": "server"}
+        win = QWidget()
+        win.setWindowTitle("LAN Assistant")
+        lay = QVBoxLayout(win)
+        lay.addWidget(QLabel("Select mode"))
+        btn_server = QPushButton("Server")
+        btn_client = QPushButton("Client")
+        lay.addWidget(btn_server)
+        lay.addWidget(btn_client)
+
+        def set_server() -> None:
+            sel["mode"] = "server"
+            app.quit()
+
+        def set_client() -> None:
+            sel["mode"] = "client"
+            app.quit()
+
+        btn_server.clicked.connect(set_server)
+        btn_client.clicked.connect(set_client)
+        win.show()
+        app.exec()
+        return sel["mode"]

--- a/lan_launcher.py
+++ b/lan_launcher.py
@@ -1,0 +1,48 @@
+"""Simple launcher enabling LAN discovery for the assistant."""
+from __future__ import annotations
+
+import argparse
+import time
+
+from lan_discovery import LanAdvertiser, discover_services, choose_mode_gui
+from remote_agent import RemoteServer, send_command
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Launch assistant with LAN discovery")
+    parser.add_argument("--mode", choices=["server", "client"], help="Run as server or client")
+    parser.add_argument("--command", default="hello", help="Command to send in client mode")
+    parser.add_argument("--timeout", type=float, default=3.0, help="Discovery timeout seconds")
+    args = parser.parse_args()
+
+    mode = args.mode or choose_mode_gui()
+
+    if mode == "server":
+        srv = RemoteServer(host="0.0.0.0", port=0, callback=print)
+        srv.start()
+        advertiser = LanAdvertiser("AI-Assistant", srv.port)
+        advertiser.start()
+        print(f"Server running on port {srv.port}. Press Ctrl+C to stop.")
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            advertiser.stop()
+            srv.shutdown()
+    else:
+        services = discover_services(timeout=args.timeout)
+        if not services:
+            print("No assistant found on LAN")
+            return
+        # Pick first discovered service
+        _name, (host, port) = next(iter(services.items()))
+        if send_command(host, port, args.command):
+            print(f"Sent '{args.command}' to {host}:{port}")
+        else:
+            print("Failed to send command")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -253,3 +253,4 @@ Werkzeug==3.1.3
 wrapt==1.17.2
 yarl==1.20.1
 zipp==3.23.0
+zeroconf==0.131.0

--- a/start_lan_assistant.bat
+++ b/start_lan_assistant.bat
@@ -1,0 +1,4 @@
+@echo off
+cd /d "%~dp0"
+python lan_launcher.py %*
+pause

--- a/start_lan_assistant.sh
+++ b/start_lan_assistant.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd "$(dirname "$0")"
+exec python3 lan_launcher.py "$@"

--- a/tests/test_lan_discovery.py
+++ b/tests/test_lan_discovery.py
@@ -1,0 +1,13 @@
+import pytest
+import lan_discovery
+
+
+@pytest.mark.skipif(lan_discovery.Zeroconf is None, reason="zeroconf missing")
+def test_advertise_and_discover():
+    adv = lan_discovery.LanAdvertiser("TestService", 42424)
+    adv.start()
+    try:
+        services = lan_discovery.discover_services(timeout=1.0)
+    finally:
+        adv.stop()
+    assert any(port == 42424 for _addr, port in services.values())


### PR DESCRIPTION
## Summary
- add `lan_discovery` module for mDNS service advertisement
- provide a simple `lan_launcher.py` using the new module
- add `.bat` and `.sh` launchers for cross platform
- document LAN discovery in README
- include `zeroconf` in requirements
- test LAN discovery functionality

## Testing
- `pip install zeroconf==0.131.0`
- `pytest tests/test_remote_agent.py tests/test_lan_discovery.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68851cd0ecfc83249ad4bc2e04f0d2c1