### PR TITLE
Add Pro Mode with HF models

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Memory viewer/editor:** adjust stored history and `memory_max` from the GUI
 - **Config editor tab:** tweak and save `config.json` without leaving the app
 - **Settings tab:** quickly switch between local and remote LLM servers
+- **Model Selection tab with Pro Mode:** instantly swap between local and Hugging Face speech models
 - **Toggle console visibility on Windows from the Settings tab**
 - **Automatic .exe scanning builds a registry of installed applications**
 - **Download game launchers like Epic Games**

--- a/config.json
+++ b/config.json
@@ -56,6 +56,9 @@
   "home_assistant_url": "",
   "home_assistant_token": "",
   "enable_home_assistant": false,
+  "pro_mode": false,
+  "tts_backend": "coqui",
+  "stt_backend": "vosk",
   "api_keys": {
     "openai": "",
     "anthropic": "",

--- a/modules/hf_stt.py
+++ b/modules/hf_stt.py
@@ -1,0 +1,43 @@
+"""Speech recognition using Hugging Face models."""
+
+from __future__ import annotations
+
+import io
+import json
+from transformers import pipeline
+import soundfile as sf
+from error_logger import log_error
+from . import gpu
+
+CONFIG_PATH = "config.json"
+DEFAULT_MODEL = "openai/whisper-small"
+
+try:
+    with open(CONFIG_PATH, "r") as f:
+        _CFG = json.load(f)
+except Exception:
+    _CFG = {}
+
+_model = None
+
+
+def _get_asr():
+    """Lazy-load and return the HF ASR pipeline."""
+    global _model
+    if _model is None:
+        model_name = _CFG.get("hf_stt_model", DEFAULT_MODEL)
+        device = 0 if gpu.is_available() else -1
+        _model = pipeline("automatic-speech-recognition", model=model_name, device=device)
+    return _model
+
+
+def recognize_from_audio(data: bytes) -> str:
+    """Return transcribed text from ``data`` containing WAV bytes."""
+    try:
+        wav, rate = sf.read(io.BytesIO(data))
+        asr = _get_asr()
+        result = asr(wav, sampling_rate=rate)
+        return result.get("text", "").strip()
+    except Exception as e:
+        log_error(f"[hf_stt] Recognition error: {e}")
+        return ""

--- a/modules/hf_tts.py
+++ b/modules/hf_tts.py
@@ -1,0 +1,56 @@
+"""Text-to-speech using Hugging Face models."""
+
+from __future__ import annotations
+
+import json
+import threading
+from transformers import pipeline
+import sounddevice as sd
+from error_logger import log_error
+from . import gpu
+
+CONFIG_PATH = "config.json"
+DEFAULT_MODEL = "facebook/fastspeech2-en-ljspeech"
+
+try:
+    with open(CONFIG_PATH, "r") as f:
+        _CFG = json.load(f)
+except Exception:
+    _CFG = {}
+
+_tts = None
+
+
+def _get_tts():
+    """Lazy-load and return the HF TTS pipeline."""
+    global _tts
+    if _tts is None:
+        model_name = _CFG.get("hf_tts_model", DEFAULT_MODEL)
+        device = 0 if gpu.is_available() else -1
+        _tts = pipeline("text-to-speech", model=model_name, device=device)
+    return _tts
+
+
+def speak(text: str, async_play: bool = True):
+    """Speak ``text`` using a Hugging Face model."""
+    try:
+        tts = _get_tts()
+        out = tts(text)
+        audio = out["audio"]
+        rate = out["sampling_rate"]
+
+        def _play():
+            try:
+                sd.play(audio, rate)
+                sd.wait()
+            except Exception as e:
+                log_error(f"[hf_tts] Playback error: {e}")
+
+        if async_play:
+            threading.Thread(target=_play, daemon=True).start()
+        else:
+            _play()
+        return "spoke"
+    except Exception as e:
+        log_error(f"[hf_tts] Error: {e}")
+        return f"[hf_tts error] {e}"

--- a/modules/hf_utils.py
+++ b/modules/hf_utils.py
@@ -1,0 +1,32 @@
+"""Utility helpers for Hugging Face features."""
+
+from __future__ import annotations
+
+import socket
+
+MODULE_NAME = "hf_utils"
+
+__all__ = ["has_internet", "get_description", "get_info"]
+
+
+def has_internet(host: str = "huggingface.co", port: int = 443, timeout: int = 3) -> bool:
+    """Return ``True`` if ``host`` is reachable over TCP."""
+    try:
+        socket.create_connection((host, port), timeout=timeout)
+        return True
+    except OSError:
+        return False
+
+
+def get_info() -> dict:
+    """Return module metadata for discovery."""
+    return {
+        "name": MODULE_NAME,
+        "description": "Utility helpers for checking network connectivity.",
+        "functions": ["has_internet"],
+    }
+
+
+def get_description() -> str:
+    """Return short description."""
+    return "Simple utilities for Hugging Face integrations."

--- a/modules/tts_manager.py
+++ b/modules/tts_manager.py
@@ -9,6 +9,9 @@ def _coqui():
 def _gtts():
     return importlib.import_module('modules.gtts_tts')
 
+def _hf():
+    return importlib.import_module('modules.hf_tts')
+
 CONFIG_PATH = "config.json"
 try:
     with open(CONFIG_PATH, "r") as f:
@@ -16,7 +19,7 @@ try:
 except Exception:
     _CFG = {}
 
-BACKEND = _CFG.get("tts_backend", "coqui")  # "coqui" or "gtts"
+BACKEND = _CFG.get("tts_backend", "coqui")  # "coqui", "gtts" or "huggingface"
 
 __all__ = ["speak", "is_speaking", "stop_speech"]
 
@@ -24,6 +27,8 @@ __all__ = ["speak", "is_speaking", "stop_speech"]
 def speak(text: str, **kwargs):
     if BACKEND == "gtts":
         return _gtts().speak(text, **kwargs)
+    if BACKEND == "huggingface":
+        return _hf().speak(text, **kwargs)
     return _coqui().speak(text, **kwargs)
 
 
@@ -36,4 +41,7 @@ def stop_speech():
 
 
 def get_description() -> str:
-    return "Routes speak() calls to gTTS or Coqui based on config.tts_backend."
+    return (
+        "Routes speak() calls to gTTS, Coqui, or Hugging Face based on "
+        "config.tts_backend."
+    )

--- a/modules/voice_input.py
+++ b/modules/voice_input.py
@@ -33,7 +33,7 @@ ENABLE_BEEP = _CFG.get("voice_beep", False)
 CANCEL_PHRASES = [p.lower() for p in _CFG.get("cancel_phrases", ["stop assistant"])]
 EXIT_PHRASES = [p.lower() for p in _CFG.get("exit_phrases", ["exit environment"])]
 SOFT_MUTE_SECS = 3
-STT_BACKEND = _CFG.get("stt_backend", "google")  # "google" or "vosk"
+STT_BACKEND = _CFG.get("stt_backend", "google")  # "google", "vosk", or "huggingface"
 
 __all__ = [
     "start_voice_listener",
@@ -187,6 +187,9 @@ def start_voice_listener(output_widget, vosk_model_path, mic_hard_muted_func, st
                 try:
                     if STT_BACKEND == "google":
                         text = recognizer.recognize_google(audio)
+                    elif STT_BACKEND == "huggingface":
+                        from modules.hf_stt import recognize_from_audio
+                        text = recognize_from_audio(audio.get_wav_data())
                     else:
                         from modules.vosk_integration import recognize_from_mic
                         text = recognize_from_mic()

--- a/tests/test_pro_mode_toggle.py
+++ b/tests/test_pro_mode_toggle.py
@@ -1,0 +1,27 @@
+import importlib
+import json
+import os
+import sys
+import types
+import pytest
+
+@pytest.mark.skipif(os.environ.get("DISPLAY") is None, reason="GUI not available")
+def test_pro_mode_toggle(monkeypatch, tmp_path):
+    cfg = {"pro_mode": False, "tts_backend": "coqui", "stt_backend": "vosk"}
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps(cfg))
+
+    from config_loader import ConfigLoader as CL
+    monkeypatch.setattr("config_loader.ConfigLoader", lambda path='config.json': CL(str(cfg_file)))
+
+    if "gui_assistant" in sys.modules:
+        del sys.modules["gui_assistant"]
+
+    ga = importlib.import_module("gui_assistant")
+    monkeypatch.setattr(ga, "has_internet", lambda: True)
+    ga.pro_var.set(True)
+    ga.toggle_pro_mode()
+    saved = json.loads(cfg_file.read_text())
+    assert saved["pro_mode"] is True
+    assert saved["tts_backend"] == "huggingface"
+    assert saved["stt_backend"] == "huggingface"

--- a/tests/test_tts_manager.py
+++ b/tests/test_tts_manager.py
@@ -10,3 +10,13 @@ def test_manager_gtts(monkeypatch):
     monkeypatch.setitem(sys.modules, 'modules.tts_integration', coqui)
     monkeypatch.setattr(mgr, 'BACKEND', 'gtts')
     assert mgr.speak('hi') == 'gtts'
+
+
+def test_manager_hf(monkeypatch):
+    mgr = importlib.import_module('modules.tts_manager')
+    hf = types.SimpleNamespace(speak=lambda text, **kw: 'hf')
+    coqui = types.SimpleNamespace(speak=lambda text, **kw: 'coqui', is_speaking=lambda: False, stop_speech=lambda: None)
+    monkeypatch.setitem(sys.modules, 'modules.hf_tts', hf)
+    monkeypatch.setitem(sys.modules, 'modules.tts_integration', coqui)
+    monkeypatch.setattr(mgr, 'BACKEND', 'huggingface')
+    assert mgr.speak('hi') == 'hf'


### PR DESCRIPTION
## Summary
- add Model Selection tab with Pro Mode toggle
- implement HF-based speech recognition and TTS
- update voice and TTS managers to handle new backend
- expand configuration to include pro mode options
- include tests for new functionality

## Testing
- `flake8 modules/hf_utils.py modules/hf_stt.py modules/hf_tts.py gui_assistant.py modules/tts_manager.py modules/voice_input.py tests/test_tts_manager.py tests/test_pro_mode_toggle.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68851fa0347083249139f337f2bc9ae8