### PR TITLE
Add GUI client launcher to LAN discovery

### DIFF
--- a/lan_launcher.py
+++ b/lan_launcher.py
@@ -2,17 +2,65 @@
 from __future__ import annotations
 
 import argparse
+import os
+import subprocess
+import sys
 import time
+from pathlib import Path
 
 from lan_discovery import LanAdvertiser, discover_services, choose_mode_gui
 from remote_agent import RemoteServer, send_command
+from error_logger import log_error
+
+
+def _show_error(msg: str) -> None:
+    """Display an error via Tkinter messagebox if available, else print."""
+    log_error(msg)
+    try:
+        import tkinter as tk
+        from tkinter import messagebox
+
+        root = tk.Tk()
+        root.withdraw()
+        messagebox.showerror("LAN Launcher", msg)
+        root.destroy()
+    except Exception:
+        print(msg)
+
+
+def _find_client_script(path: str | None = None) -> str | None:
+    """Return path to the client GUI script if it exists."""
+    if path:
+        return path if os.path.isfile(path) else None
+    base = Path(__file__).resolve().parent
+    for name in ("gui_client.py", "remote_gui_client.py"):
+        cand = base / name
+        if cand.is_file():
+            return str(cand)
+    return None
+
+
+def launch_client_gui(host: str, port: int, client_path: str | None = None) -> bool:
+    """Launch the LAN client GUI as a subprocess."""
+    script = _find_client_script(client_path)
+    if not script:
+        _show_error("Client GUI script not found. Please specify --client-path.")
+        return False
+    cmd = [sys.executable, script, "--host", host, "--port", str(port)]
+    try:
+        subprocess.Popen(cmd)
+    except Exception as exc:  # pragma: no cover - subprocess errors
+        _show_error(f"Failed to start client GUI: {exc}")
+        return False
+    return True
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Launch assistant with LAN discovery")
     parser.add_argument("--mode", choices=["server", "client"], help="Run as server or client")
-    parser.add_argument("--command", default="hello", help="Command to send in client mode")
+    parser.add_argument("--command", help="Command to send instead of launching GUI")
     parser.add_argument("--timeout", type=float, default=3.0, help="Discovery timeout seconds")
+    parser.add_argument("--client-path", help="Path to client GUI script")
     args = parser.parse_args()
 
     mode = args.mode or choose_mode_gui()
@@ -34,14 +82,16 @@ def main() -> None:
     else:
         services = discover_services(timeout=args.timeout)
         if not services:
-            print("No assistant found on LAN")
+            _show_error("No assistant found on LAN")
             return
-        # Pick first discovered service
         _name, (host, port) = next(iter(services.items()))
-        if send_command(host, port, args.command):
-            print(f"Sent '{args.command}' to {host}:{port}")
+        if args.command:
+            if send_command(host, port, args.command):
+                print(f"Sent '{args.command}' to {host}:{port}")
+            else:
+                _show_error("Failed to send command")
         else:
-            print("Failed to send command")
+            launch_client_gui(host, port, args.client_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_lan_launcher.py
+++ b/tests/test_lan_launcher.py
@@ -1,0 +1,25 @@
+import sys
+import lan_launcher as ll
+
+
+def test_launch_client_gui_runs(monkeypatch, tmp_path):
+    script = tmp_path / "gui_client.py"
+    script.write_text("print('ok')")
+    called = {}
+    def fake_popen(cmd):
+        called['cmd'] = cmd
+        class Dummy:
+            pass
+        return Dummy()
+    monkeypatch.setattr(ll.subprocess, 'Popen', fake_popen)
+    assert ll.launch_client_gui('1.2.3.4', 1234, str(script))
+    assert called['cmd'][0] == sys.executable
+    assert str(script) in called['cmd']
+    assert '--host' in called['cmd'] and '1.2.3.4' in called['cmd']
+
+
+def test_launch_client_gui_missing(monkeypatch):
+    msgs = []
+    monkeypatch.setattr(ll, '_show_error', lambda m: msgs.append(m))
+    assert ll.launch_client_gui('0.0.0.0', 1, 'missing.py') is False
+    assert msgs and 'not found' in msgs[0]


### PR DESCRIPTION
## Summary
- extend LAN launcher to start the client GUI when in client mode
- add helper utilities for detecting and launching the GUI script
- provide Tkinter error popups and logging via `log_error`
- support optional command sending or GUI launching
- add unit tests for launcher helpers

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852d244afc8324b77311846c6de9e8