### PR TITLE
Add Hugging Face model settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A privacy-first, voice-enabled local AI assistant with modular automation, custo
 - **Config editor tab:** tweak and save `config.json` without leaving the app
 - **Settings tab:** quickly switch between local and remote LLM servers
 - **Model Selection tab with Pro Mode:** instantly swap between local and Hugging Face speech models
+- **Choose HF STT and TTS models in Pro Mode for local paths or custom names**
 - **Toggle console visibility on Windows from the Settings tab**
 - **Automatic .exe scanning builds a registry of installed applications**
 - **Download game launchers like Epic Games**

--- a/config.json
+++ b/config.json
@@ -59,6 +59,8 @@
   "pro_mode": false,
   "tts_backend": "coqui",
   "stt_backend": "vosk",
+  "hf_tts_model": "facebook/fastspeech2-en-ljspeech",
+  "hf_stt_model": "openai/whisper-small",
   "api_keys": {
     "openai": "",
     "anthropic": "",

--- a/config_validator.py
+++ b/config_validator.py
@@ -50,6 +50,8 @@ CONFIG_SCHEMA = {
         "max_speech_length": {"type": "number"},
         "auto_sleep_timeout": {"type": "number"},
         "voice_beep": {"type": "boolean"},
+        "hf_tts_model": {"type": "string"},
+        "hf_stt_model": {"type": "string"},
         "log_level": {"type": "string"},
         "enable_advanced_logging": {"type": "boolean"},
         "busy_timeout": {"type": "number"},

--- a/gui_assistant.py
+++ b/gui_assistant.py
@@ -1618,6 +1618,75 @@ _toggle_remote()
 
 # ---------- Model Selection Section ----------
 pro_var = tk.BooleanVar(value=config.get("pro_mode", False))
+hf_tts_var = tk.StringVar(value=config.get("hf_tts_model", ""))
+hf_stt_var = tk.StringVar(value=config.get("hf_stt_model", ""))
+
+# Frames for Hugging Face model paths
+hf_tts_frame = ttk.Frame(settings_tab)
+ttk.Label(hf_tts_frame, text="HF TTS Model:").pack(side=tk.LEFT)
+hf_tts_entry = ttk.Entry(hf_tts_frame, textvariable=hf_tts_var, width=40)
+hf_tts_entry.pack(side=tk.LEFT, fill="x", expand=True, padx=(5, 0))
+
+
+def browse_hf_tts_model() -> None:
+    path = filedialog.askdirectory(title="Select HF TTS Model") or ""
+    if path:
+        hf_tts_var.set(path)
+
+
+def save_hf_tts_model() -> None:
+    from modules import hf_tts
+    cfg = config_loader.config
+    cfg["hf_tts_model"] = hf_tts_var.get().strip()
+    with open("config.json", "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+    config_loader.config = cfg
+    hf_tts._CFG = cfg  # type: ignore
+    hf_tts._tts = None  # reset to load new model on next speak
+    reload_config()
+    output.insert(tk.END, f"[SYSTEM] HF TTS model set to {hf_tts_var.get()}\n")
+
+
+ttk.Button(hf_tts_frame, text="Browse", command=browse_hf_tts_model).pack(side=tk.LEFT, padx=5)
+ttk.Button(hf_tts_frame, text="Save", command=save_hf_tts_model).pack(side=tk.LEFT)
+
+hf_stt_frame = ttk.Frame(settings_tab)
+ttk.Label(hf_stt_frame, text="HF STT Model:").pack(side=tk.LEFT)
+hf_stt_entry = ttk.Entry(hf_stt_frame, textvariable=hf_stt_var, width=40)
+hf_stt_entry.pack(side=tk.LEFT, fill="x", expand=True, padx=(5, 0))
+
+
+def browse_hf_stt_model() -> None:
+    path = filedialog.askdirectory(title="Select HF STT Model") or ""
+    if path:
+        hf_stt_var.set(path)
+
+
+def save_hf_stt_model() -> None:
+    from modules import hf_stt
+    cfg = config_loader.config
+    cfg["hf_stt_model"] = hf_stt_var.get().strip()
+    with open("config.json", "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+    config_loader.config = cfg
+    hf_stt._CFG = cfg  # type: ignore
+    hf_stt._model = None  # reset to load new model on next recognition
+    reload_config()
+    output.insert(tk.END, f"[SYSTEM] HF STT model set to {hf_stt_var.get()}\n")
+
+
+ttk.Button(hf_stt_frame, text="Browse", command=browse_hf_stt_model).pack(side=tk.LEFT, padx=5)
+ttk.Button(hf_stt_frame, text="Save", command=save_hf_stt_model).pack(side=tk.LEFT)
+
+
+def _update_pro_widgets() -> None:
+    """Show or hide HF model selection widgets based on Pro Mode."""
+    if pro_var.get():
+        hf_tts_frame.pack(fill="x", padx=10, pady=(5, 0))
+        hf_stt_frame.pack(fill="x", padx=10, pady=(0, 5))
+    else:
+        hf_tts_frame.pack_forget()
+        hf_stt_frame.pack_forget()
 
 
 def toggle_pro_mode() -> None:
@@ -1643,6 +1712,7 @@ def toggle_pro_mode() -> None:
         json.dump(cfg, f, indent=2)
     config_loader.config = cfg
     reload_config()
+    _update_pro_widgets()
     output.insert(tk.END, f"[SYSTEM] Pro Mode {'enabled' if pro_var.get() else 'disabled'}.\n")
 
 
@@ -1652,6 +1722,7 @@ ttk.Checkbutton(
     variable=pro_var,
     command=toggle_pro_mode,
 ).pack(anchor="w", padx=10, pady=10)
+_update_pro_widgets()
 
 # ---------- Speech Learning Tab ----------
 speech_label = ttk.Label(

--- a/tests/test_hf_model_save.py
+++ b/tests/test_hf_model_save.py
@@ -1,0 +1,27 @@
+import importlib
+import json
+import os
+import sys
+import pytest
+
+@pytest.mark.skipif(os.environ.get("DISPLAY") is None, reason="GUI not available")
+def test_save_hf_models(monkeypatch, tmp_path):
+    cfg = {"pro_mode": True, "hf_tts_model": "", "hf_stt_model": ""}
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps(cfg))
+
+    from config_loader import ConfigLoader as CL
+    monkeypatch.setattr("config_loader.ConfigLoader", lambda path='config.json': CL(str(cfg_file)))
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "1")
+    if "gui_assistant" in sys.modules:
+        del sys.modules["gui_assistant"]
+    ga = importlib.import_module("gui_assistant")
+    ga.hf_tts_var.set("tts")
+    ga.save_hf_tts_model()
+    ga.hf_stt_var.set("stt")
+    ga.save_hf_stt_model()
+
+    saved = json.loads(cfg_file.read_text())
+    assert saved["hf_tts_model"] == "tts"
+    assert saved["hf_stt_model"] == "stt"


### PR DESCRIPTION
## Summary
- support HF STT/TTS model paths in the settings tab
- allow saving these models and toggling visibility with Pro Mode
- validate new config fields
- document HF model options in README
- test saving HF model paths

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855e7365b8832493003934598b9c89